### PR TITLE
[SYCL][Reduction] Optimize reduCGFuncForRangeFastAtomics for discrete GPU

### DIFF
--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -491,24 +491,32 @@ protected:
 template <class T>
 struct is_rw_acc_t : public std::false_type {};
 
-template <class T, int AccessorDims, access::placeholder IsPlaceholder>
-struct is_rw_acc_t<
-    accessor<T, AccessorDims, access::mode::read_write, access::target::device,
-             IsPlaceholder, ext::oneapi::accessor_property_list<>>>
+template <class T, int AccessorDims, access::placeholder IsPlaceholder,
+          typename PropList>
+struct is_rw_acc_t<accessor<T, AccessorDims, access::mode::read_write,
+                            access::target::device, IsPlaceholder, PropList>>
     : public std::true_type {};
 
 template <class T>
 struct is_dw_acc_t : public std::false_type {};
 
-template <class T, int AccessorDims, access::placeholder IsPlaceholder>
+template <class T, int AccessorDims, access::placeholder IsPlaceholder,
+          typename PropList>
 struct is_dw_acc_t<accessor<T, AccessorDims, access::mode::discard_write,
-                            access::target::device, IsPlaceholder,
-                            ext::oneapi::accessor_property_list<>>>
+                            access::target::device, IsPlaceholder, PropList>>
+    : public std::true_type {};
+
+template <class T>
+struct is_placeholder_t : public std::false_type {};
+
+template <class T, int AccessorDims, access::mode Mode, typename PropList>
+struct is_placeholder_t<accessor<T, AccessorDims, Mode, access::target::device,
+                                 access::placeholder::true_t, PropList>>
     : public std::true_type {};
 
 /// Types representing specific reduction algorithms
 /// Enables reduction_impl_algo to take additional algorithm-specific templates
-template <access::placeholder IsPlaceholder, int AccessorDims>
+template <int AccessorDims>
 class default_reduction_algorithm {};
 
 /// Templated class for implementations of specific reduction algorithms
@@ -519,16 +527,15 @@ class reduction_impl_algo;
 /// Original reduction algorithm is the default. It supports both USM and
 /// accessors via a single class
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          access::placeholder IsPlaceholder, int AccessorDims,
-          typename RedOutVar>
+          int AccessorDims, typename RedOutVar>
 class reduction_impl_algo<
     T, BinaryOperation, Dims, Extent,
-    default_reduction_algorithm<IsPlaceholder, AccessorDims>, RedOutVar>
+    default_reduction_algorithm<AccessorDims>, RedOutVar>
     : public reduction_impl_common<T, BinaryOperation> {
   using base = reduction_impl_common<T, BinaryOperation>;
-  using self = reduction_impl_algo<
-      T, BinaryOperation, Dims, Extent,
-      default_reduction_algorithm<IsPlaceholder, AccessorDims>, RedOutVar>;
+  using self =
+      reduction_impl_algo<T, BinaryOperation, Dims, Extent,
+                          default_reduction_algorithm<AccessorDims>, RedOutVar>;
 
 public:
   using reducer_type = reducer<T, BinaryOperation, Dims, Extent>;
@@ -540,15 +547,12 @@ public:
   // AccessorDims also determines the dimensionality of some temp storage
   static constexpr int accessor_dim = AccessorDims;
   static constexpr int buffer_dim = (AccessorDims == 0) ? 1 : AccessorDims;
+  static constexpr access::placeholder is_placeholder =
+      is_placeholder_t<RedOutVar>::value ? access::placeholder::true_t
+                                         : access::placeholder::false_t;
   using rw_accessor_type = accessor<T, AccessorDims, access::mode::read_write,
-                                    access::target::device, IsPlaceholder,
+                                    access::target::device, is_placeholder,
                                     ext::oneapi::accessor_property_list<>>;
-  using dw_accessor_type =
-      accessor<T, AccessorDims, access::mode::discard_write,
-               access::target::device, IsPlaceholder,
-               ext::oneapi::accessor_property_list<>>;
-
-
   static constexpr bool has_atomic_add_float64 =
       IsReduOptForAtomic64Add<T, BinaryOperation>::value;
   static constexpr bool has_fast_atomics =
@@ -561,9 +565,6 @@ public:
 
   static constexpr bool my_is_rw_acc = is_rw_acc_t<RedOutVar>::value;
   static constexpr bool my_is_dw_acc = is_dw_acc_t<RedOutVar>::value;
-
-  static constexpr bool is_placeholder =
-      (IsPlaceholder == access::placeholder::true_t);
 
   static constexpr size_t dims = Dims;
   static constexpr size_t num_elements = Extent;
@@ -697,14 +698,16 @@ public:
   }
 
 private:
-  template <typename BufferT, access::placeholder IsPH = IsPlaceholder>
-  std::enable_if_t<IsPH == access::placeholder::false_t, rw_accessor_type>
+  template <typename BufferT, typename _self = self>
+  std::enable_if_t<_self::is_placeholder == access::placeholder::false_t,
+                   rw_accessor_type>
   createHandlerWiredReadWriteAccessor(handler &CGH, BufferT Buffer) {
     return {Buffer, CGH};
   }
 
-  template <typename BufferT, access::placeholder IsPH = IsPlaceholder>
-  std::enable_if_t<IsPH == access::placeholder::true_t, rw_accessor_type>
+  template <typename BufferT, typename _self = self>
+  std::enable_if_t<_self::is_placeholder == access::placeholder::true_t,
+                   rw_accessor_type>
   createHandlerWiredReadWriteAccessor(handler &CGH, BufferT Buffer) {
     rw_accessor_type Acc(Buffer);
     CGH.require(Acc);
@@ -778,7 +781,6 @@ public:
 
   using reducer_type = typename algo::reducer_type;
   using rw_accessor_type = typename algo::rw_accessor_type;
-  using dw_accessor_type = typename algo::dw_accessor_type;
 
   // Only scalar and 1D array reductions are supported by SYCL 2020.
   static_assert(Dims <= 1, "Multi-dimensional reductions are not supported.");
@@ -2457,7 +2459,7 @@ tuple_select_elements(TupleT Tuple, std::index_sequence<Is...>) {
 template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
           access::placeholder IsPH>
 detail::reduction_impl<T, BinaryOperation, 0, 1,
-                       detail::default_reduction_algorithm<IsPH, Dims>,
+                       detail::default_reduction_algorithm<Dims>,
                        accessor<T, Dims, AccMode, access::target::device, IsPH>>
 reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
           const T &Identity, BinaryOperation BOp) {
@@ -2473,7 +2475,7 @@ template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
 std::enable_if_t<sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
                  detail::reduction_impl<
                      T, BinaryOperation, 0, 1,
-                     detail::default_reduction_algorithm<IsPH, Dims>,
+                     detail::default_reduction_algorithm<Dims>,
                      accessor<T, Dims, AccMode, access::target::device, IsPH>>>
 reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
           BinaryOperation) {
@@ -2485,9 +2487,8 @@ reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
 /// the computed reduction must be stored \param VarPtr, identity value
 /// \param Identity, and the binary operation used in the reduction.
 template <typename T, class BinaryOperation>
-detail::reduction_impl<
-    T, BinaryOperation, 0, 1,
-    detail::default_reduction_algorithm<access::placeholder::false_t, 1>, T *>
+detail::reduction_impl<T, BinaryOperation, 0, 1,
+                       detail::default_reduction_algorithm<1>, T *>
 reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
   return {VarPtr, Identity, BOp};
 }
@@ -2498,11 +2499,10 @@ reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
 /// operation used in the reduction.
 /// The identity value is not passed to this version as it is statically known.
 template <typename T, class BinaryOperation>
-std::enable_if_t<sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
-                 detail::reduction_impl<T, BinaryOperation, 0, 1,
-                                        detail::default_reduction_algorithm<
-                                            access::placeholder::false_t, 1>,
-                                        T *>>
+std::enable_if_t<
+    sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
+    detail::reduction_impl<T, BinaryOperation, 0, 1,
+                           detail::default_reduction_algorithm<1>, T *>>
 reduction(T *VarPtr, BinaryOperation) {
   return {VarPtr};
 }

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -2024,6 +2024,7 @@ namespace main_krn {
 template <class KernelName> struct NDRangeAtomic64;
 } // namespace main_krn
 } // namespace reduction
+
 // Specialization for devices with the atomic64 aspect, which guarantees 64 (and
 // temporarily 32) bit floating point support for atomic add.
 // TODO 32 bit floating point atomics are eventually expected to be supported by
@@ -2031,9 +2032,9 @@ template <class KernelName> struct NDRangeAtomic64;
 // IsReduOptForAtomic64Add, as prescribed in its documentation, should then also
 // be made.
 template <typename KernelName, typename KernelType, int Dims, class Reduction>
-void reduCGFuncImplAtomic64(handler &CGH, KernelType KernelFunc,
-                            const nd_range<Dims> &Range, Reduction &,
-                            typename Reduction::rw_accessor_type Out) {
+void reduCGFuncAtomic64(handler &CGH, KernelType KernelFunc,
+                        const nd_range<Dims> &Range, Reduction &Redu) {
+  auto Out = Redu.getReadWriteAccessorToInitializedMem(CGH);
   static_assert(Reduction::has_atomic_add_float64,
                 "Only suitable for reductions that have FP64 atomic add.");
   constexpr size_t NElements = Reduction::num_elements;
@@ -2056,20 +2057,6 @@ void reduCGFuncImplAtomic64(handler &CGH, KernelType KernelFunc,
       Reducer.atomic_combine(Reduction::getOutPointer(Out));
     }
   });
-}
-
-// Specialization for devices with the atomic64 aspect, which guarantees 64 (and
-// temporarily 32) bit floating point support for atomic add.
-// TODO 32 bit floating point atomics are eventually expected to be supported by
-// the has_fast_atomics specialization. Corresponding changes to
-// IsReduOptForAtomic64Add, as prescribed in its documentation, should then also
-// be made.
-template <typename KernelName, typename KernelType, int Dims, class Reduction>
-void reduCGFuncAtomic64(handler &CGH, KernelType KernelFunc,
-                        const nd_range<Dims> &Range, Reduction &Redu) {
-  auto Out = Redu.getReadWriteAccessorToInitializedMem(CGH);
-  reduCGFuncImplAtomic64<KernelName, KernelType, Dims, Reduction>(
-      CGH, KernelFunc, Range, Redu, Out);
 }
 
 template <typename... Reductions, size_t... Is>

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -513,22 +513,23 @@ class default_reduction_algorithm {};
 
 /// Templated class for implementations of specific reduction algorithms
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          typename RedOutVar, class Algorithm>
+          class Algorithm, typename RedOutVar>
 class reduction_impl_algo;
 
 /// Original reduction algorithm is the default. It supports both USM and
 /// accessors via a single class
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          typename RedOutVar, bool IsUSM, access::placeholder IsPlaceholder,
-          int AccessorDims>
+          bool IsUSM, access::placeholder IsPlaceholder, int AccessorDims,
+          typename RedOutVar>
 class reduction_impl_algo<
-    T, BinaryOperation, Dims, Extent, RedOutVar,
-    default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>>
+    T, BinaryOperation, Dims, Extent,
+    default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>, RedOutVar>
     : public reduction_impl_common<T, BinaryOperation> {
   using base = reduction_impl_common<T, BinaryOperation>;
   using self = reduction_impl_algo<
-      T, BinaryOperation, Dims, Extent, RedOutVar,
-      default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>>;
+      T, BinaryOperation, Dims, Extent,
+      default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>,
+      RedOutVar>;
 
 public:
   using reducer_type = reducer<T, BinaryOperation, Dims, Extent>;
@@ -736,15 +737,16 @@ template <typename T> struct AreAllButLastReductions<T> {
 /// This class encapsulates the reduction variable/accessor,
 /// the reduction operator and an optional operator identity.
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          typename RedOutVar, class Algorithm>
+          class Algorithm, typename RedOutVar>
 class reduction_impl
     : private reduction_impl_base,
-      public reduction_impl_algo<T, BinaryOperation, Dims, Extent, RedOutVar,
-                                 Algorithm> {
+      public reduction_impl_algo<T, BinaryOperation, Dims, Extent, Algorithm,
+                                 RedOutVar> {
 private:
-  using algo = reduction_impl_algo<T, BinaryOperation, Dims, Extent, RedOutVar,
-                                   Algorithm>;
-  using self = reduction_impl<T, BinaryOperation, Dims, Extent, RedOutVar, Algorithm>;
+  using algo = reduction_impl_algo<T, BinaryOperation, Dims, Extent,
+                                   Algorithm, RedOutVar>;
+  using self =
+      reduction_impl<T, BinaryOperation, Dims, Extent, Algorithm, RedOutVar>;
 
   static constexpr bool is_known_identity =
       sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value;
@@ -2457,8 +2459,8 @@ tuple_select_elements(TupleT Tuple, std::index_sequence<Is...>) {
 template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
           access::placeholder IsPH>
 detail::reduction_impl<T, BinaryOperation, 0, 1,
-                       accessor<T, Dims, AccMode, access::target::device, IsPH>,
-                       detail::default_reduction_algorithm<false, IsPH, Dims>>
+                       detail::default_reduction_algorithm<false, IsPH, Dims>,
+                       accessor<T, Dims, AccMode, access::target::device, IsPH>>
 reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
           const T &Identity, BinaryOperation BOp) {
   return {Acc, Identity, BOp};
@@ -2473,8 +2475,8 @@ template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
 std::enable_if_t<sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
                  detail::reduction_impl<
                      T, BinaryOperation, 0, 1,
-                     accessor<T, Dims, AccMode, access::target::device, IsPH>,
-                     detail::default_reduction_algorithm<false, IsPH, Dims>>>
+                     detail::default_reduction_algorithm<false, IsPH, Dims>,
+                     accessor<T, Dims, AccMode, access::target::device, IsPH>>>
 reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
           BinaryOperation) {
   return {Acc};
@@ -2486,8 +2488,9 @@ reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
 /// \param Identity, and the binary operation used in the reduction.
 template <typename T, class BinaryOperation>
 detail::reduction_impl<
-    T, BinaryOperation, 0, 1, T *,
-    detail::default_reduction_algorithm<true, access::placeholder::false_t, 1>>
+    T, BinaryOperation, 0, 1,
+    detail::default_reduction_algorithm<true, access::placeholder::false_t, 1>,
+    T *>
 reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
   return {VarPtr, Identity, BOp};
 }
@@ -2500,9 +2503,10 @@ reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
 template <typename T, class BinaryOperation>
 std::enable_if_t<
     sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
-    detail::reduction_impl<T, BinaryOperation, 0, 1, T *,
+    detail::reduction_impl<T, BinaryOperation, 0, 1,
                            detail::default_reduction_algorithm<
-                               true, access::placeholder::false_t, 1>>>
+                               true, access::placeholder::false_t, 1>,
+                           T *>>
 reduction(T *VarPtr, BinaryOperation) {
   return {VarPtr};
 }

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -488,8 +488,7 @@ protected:
   bool InitializeToIdentity;
 };
 
-template <class T>
-struct is_rw_acc_t : public std::false_type {};
+template <class T> struct is_rw_acc_t : public std::false_type {};
 
 template <class T, int AccessorDims, access::placeholder IsPlaceholder,
           typename PropList>
@@ -497,8 +496,7 @@ struct is_rw_acc_t<accessor<T, AccessorDims, access::mode::read_write,
                             access::target::device, IsPlaceholder, PropList>>
     : public std::true_type {};
 
-template <class T>
-struct is_dw_acc_t : public std::false_type {};
+template <class T> struct is_dw_acc_t : public std::false_type {};
 
 template <class T, int AccessorDims, access::placeholder IsPlaceholder,
           typename PropList>
@@ -506,17 +504,14 @@ struct is_dw_acc_t<accessor<T, AccessorDims, access::mode::discard_write,
                             access::target::device, IsPlaceholder, PropList>>
     : public std::true_type {};
 
-template <class T>
-struct is_placeholder_t : public std::false_type {};
+template <class T> struct is_placeholder_t : public std::false_type {};
 
 template <class T, int AccessorDims, access::mode Mode, typename PropList>
 struct is_placeholder_t<accessor<T, AccessorDims, Mode, access::target::device,
                                  access::placeholder::true_t, PropList>>
     : public std::true_type {};
 
-
-template <class T>
-struct accessor_dim_t {
+template <class T> struct accessor_dim_t {
   static constexpr int value = 1;
 };
 
@@ -528,7 +523,7 @@ struct accessor_dim_t<
 };
 
 template <class T> struct get_red_t;
-template <class T> struct get_red_t<T*> {
+template <class T> struct get_red_t<T *> {
   using type = T;
 };
 
@@ -782,10 +777,10 @@ private:
   }
 
 public:
-  using algo::is_usm;
-  using algo::is_rw_acc;
-  using algo::is_dw_acc;
   using algo::is_acc;
+  using algo::is_dw_acc;
+  using algo::is_rw_acc;
+  using algo::is_usm;
 
   using reducer_type = typename algo::reducer_type;
   using rw_accessor_type = typename algo::rw_accessor_type;
@@ -808,8 +803,8 @@ public:
   /// The \param VarPtr is a USM pointer to memory, to where the computed
   /// reduction value is added using BinaryOperation, i.e. it is expected that
   /// the memory is pre-initialized with some meaningful value.
-  template <typename _self = self, enable_if_t<_self::is_known_identity &&
-                                               _self::is_usm> * = nullptr>
+  template <typename _self = self,
+            enable_if_t<_self::is_known_identity && _self::is_usm> * = nullptr>
   reduction_impl(RedOutVar VarPtr, bool InitializeToIdentity = false)
       : algo(reducer_type::getIdentity(), BinaryOperation(),
              InitializeToIdentity, VarPtr) {}
@@ -862,9 +857,10 @@ public:
 
 template <class BinaryOp, int Dims, size_t Extent, typename RedOutVar,
           typename... RestTy>
-auto make_reduction(RedOutVar RedVar, RestTy &&... Rest) {
+auto make_reduction(RedOutVar RedVar, RestTy &&...Rest) {
   return reduction_impl<typename get_red_t<RedOutVar>::type, BinaryOp, Dims,
-                        Extent, RedOutVar>{RedVar, std::forward<RestTy>(Rest)...};
+                        Extent, RedOutVar>{RedVar,
+                                           std::forward<RestTy>(Rest)...};
 }
 
 /// A helper to pass undefined (sycl::detail::auto_name) names unmodified. We
@@ -1269,7 +1265,6 @@ void reduCGFuncForNDRangeFastAtomicsOnly(
     if (LID == 0) {
       Reducer.atomic_combine(Reduction::getOutPointer(Out));
     }
-
   });
 }
 
@@ -1797,7 +1792,9 @@ struct IsNonUsmReductionPredicate {
 };
 
 struct EmptyReductionPredicate {
-  template <typename T> struct Func { static constexpr bool value = false; };
+  template <typename T> struct Func {
+    static constexpr bool value = false;
+  };
 };
 
 template <bool Cond, size_t I> struct FilterElement {
@@ -2111,7 +2108,7 @@ void associateReduAccsWithHandlerHelper(handler &CGH, ReductionT &Redu) {
 template <typename ReductionT, typename... RestT,
           enable_if_t<(sizeof...(RestT) > 0), int> Z = 0>
 void associateReduAccsWithHandlerHelper(handler &CGH, ReductionT &Redu,
-                                        RestT &... Rest) {
+                                        RestT &...Rest) {
   Redu.associateWithHandler(CGH);
   associateReduAccsWithHandlerHelper(CGH, Rest...);
 }
@@ -2511,15 +2508,15 @@ __SYCL_INLINE_CONSTEXPR AccumulatorT known_identity_v =
 
 #ifdef __SYCL_INTERNAL_API
 namespace __SYCL2020_DEPRECATED("use 'ext::oneapi' instead") ONEAPI {
-  using namespace ext::oneapi;
-  namespace detail {
-  using cl::sycl::detail::queue_impl;
-  __SYCL_EXPORT size_t reduGetMaxWGSize(std::shared_ptr<queue_impl> Queue,
-                                        size_t LocalMemBytesPerWorkItem);
-  __SYCL_EXPORT size_t reduComputeWGSize(size_t NWorkItems, size_t MaxWGSize,
-                                         size_t &NWorkGroups);
-  } // namespace detail
-} // namespace ONEAPI
+using namespace ext::oneapi;
+namespace detail {
+using cl::sycl::detail::queue_impl;
+__SYCL_EXPORT size_t reduGetMaxWGSize(std::shared_ptr<queue_impl> Queue,
+                                      size_t LocalMemBytesPerWorkItem);
+__SYCL_EXPORT size_t reduComputeWGSize(size_t NWorkItems, size_t MaxWGSize,
+                                       size_t &NWorkGroups);
+} // namespace detail
+} // namespace __SYCL2020_DEPRECATED("use 'ext::oneapi' instead")ONEAPI
 #endif // __SYCL_INTERNAL_API
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -790,21 +790,6 @@ public:
   // Only scalar and 1D array reductions are supported by SYCL 2020.
   static_assert(Dims <= 1, "Multi-dimensional reductions are not supported.");
 
-  /// SYCL-2020.
-  /// Constructs reduction_impl when the identity value is statically known.
-  template <typename _self = self,
-            std::enable_if_t<_self::is_known_identity && _self::my_is_rw_acc>
-                * = nullptr>
-  reduction_impl(RedOutVar &Acc, handler &CGH, bool InitializeToIdentity)
-      : algo(reducer_type::getIdentity(), BinaryOperation(),
-             InitializeToIdentity, Acc) {
-    algo::associateWithHandler(CGH);
-    if (Acc.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_ERROR_INVALID_VALUE);
-  }
-
   /// Constructs reduction_impl when the identity value is statically known.
   template <typename _self = self,
             enable_if_t<_self::is_known_identity &&
@@ -817,15 +802,24 @@ public:
                                 PI_ERROR_INVALID_VALUE);
   }
 
+  /// Constructs reduction_impl when the identity value is statically known.
+  /// The \param VarPtr is a USM pointer to memory, to where the computed
+  /// reduction value is added using BinaryOperation, i.e. it is expected that
+  /// the memory is pre-initialized with some meaningful value.
+  template <typename _self = self, enable_if_t<_self::is_known_identity &&
+                                               _self::my_is_usm> * = nullptr>
+  reduction_impl(RedOutVar VarPtr, bool InitializeToIdentity = false)
+      : algo(reducer_type::getIdentity(), BinaryOperation(),
+             InitializeToIdentity, VarPtr) {}
+
   /// SYCL-2020.
-  /// Constructs reduction_impl when the identity value is statically known,
-  /// and user still passed the identity value.
-  /// SYCL-2020.
-  /// Constructs reduction_impl when the identity value is NOT known statically.
-  template <typename _self = self, enable_if_t<_self::my_is_rw_acc> * = nullptr>
-  reduction_impl(RedOutVar &Acc, handler &CGH, const T &Identity,
-                 BinaryOperation BOp, bool InitializeToIdentity)
-      : algo(chooseIdentity(Identity), BOp, InitializeToIdentity, Acc) {
+  /// Constructs reduction_impl when the identity value is statically known.
+  template <typename _self = self,
+            std::enable_if_t<_self::is_known_identity && _self::my_is_rw_acc>
+                * = nullptr>
+  reduction_impl(RedOutVar &Acc, handler &CGH, bool InitializeToIdentity)
+      : algo(reducer_type::getIdentity(), BinaryOperation(),
+             InitializeToIdentity, Acc) {
     algo::associateWithHandler(CGH);
     if (Acc.size() != 1)
       throw sycl::runtime_error(errc::invalid,
@@ -844,23 +838,25 @@ public:
                                 PI_ERROR_INVALID_VALUE);
   }
 
-  /// Constructs reduction_impl when the identity value is statically known.
-  /// The \param VarPtr is a USM pointer to memory, to where the computed
-  /// reduction value is added using BinaryOperation, i.e. it is expected that
-  /// the memory is pre-initialized with some meaningful value.
-  template <typename _self = self, enable_if_t<_self::is_known_identity &&
-                                               _self::my_is_usm> * = nullptr>
-  reduction_impl(T *VarPtr, bool InitializeToIdentity = false)
-      : algo(reducer_type::getIdentity(), BinaryOperation(),
-             InitializeToIdentity, VarPtr) {}
-
   /// The \param VarPtr is a USM pointer to memory, to where the computed
   /// reduction value is added using BinaryOperation, i.e. it is expected that
   /// the memory is pre-initialized with some meaningful value.
   template <typename _self = self, enable_if_t<_self::my_is_usm> * = nullptr>
-  reduction_impl(T *VarPtr, const T &Identity, BinaryOperation BOp,
+  reduction_impl(RedOutVar VarPtr, const T &Identity, BinaryOperation BOp,
                  bool InitializeToIdentity = false)
       : algo(chooseIdentity(Identity), BOp, InitializeToIdentity, VarPtr) {}
+
+  /// For placeholder accessor.
+  template <typename _self = self, enable_if_t<_self::my_is_rw_acc> * = nullptr>
+  reduction_impl(RedOutVar &Acc, handler &CGH, const T &Identity,
+                 BinaryOperation BOp, bool InitializeToIdentity)
+      : algo(chooseIdentity(Identity), BOp, InitializeToIdentity, Acc) {
+    algo::associateWithHandler(CGH);
+    if (Acc.size() != 1)
+      throw sycl::runtime_error(errc::invalid,
+                                "Reduction variable must be a scalar.",
+                                PI_ERROR_INVALID_VALUE);
+  }
 };
 
 template <class BinaryOp, int Dims, size_t Extent, typename RedOutVar,

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -571,16 +571,19 @@ public:
             std::enable_if_t<_self::my_is_rw_acc> * = nullptr>
   reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
                       std::shared_ptr<rw_accessor_type> AccPointer)
-      : base(Identity, BinaryOp, Init), MRWAcc(AccPointer){};
+      : base(Identity, BinaryOp, Init), MRWAcc(AccPointer),
+        MRedOut(*AccPointer){};
   template <class _self = self,
             std::enable_if_t<_self::my_is_dw_acc> * = nullptr>
   reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
                       std::shared_ptr<dw_accessor_type> AccPointer)
-      : base(Identity, BinaryOp, Init), MDWAcc(AccPointer){};
+      : base(Identity, BinaryOp, Init), MDWAcc(AccPointer),
+        MRedOut(*AccPointer){};
   template <class _self = self, std::enable_if_t<_self::my_is_usm> * = nullptr>
   reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
                       T *USMPointer)
-      : base(Identity, BinaryOp, Init), MUSMPointer(USMPointer){};
+      : base(Identity, BinaryOp, Init), MUSMPointer(USMPointer),
+        MRedOut(MUSMPointer){};
 
   /// Associates the reduction accessor to user's memory with \p CGH handler
   /// to keep the accessor alive until the command group finishes the work.
@@ -730,7 +733,6 @@ private:
     return Acc;
   }
 
-  RedOutVar *MRedOut;
   /// User's accessor to where the reduction must be written.
   std::shared_ptr<rw_accessor_type> MRWAcc;
   std::shared_ptr<dw_accessor_type> MDWAcc;
@@ -740,6 +742,8 @@ private:
   /// USM pointer referencing the memory to where the result of the reduction
   /// must be written. Applicable/used only for USM reductions.
   T *MUSMPointer = nullptr;
+
+  RedOutVar &MRedOut;
 };
 
 /// Predicate returning true if all template type parameters except the last one

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -606,6 +606,13 @@ public:
     }
   }
 
+  template <class _T = T, int D = buffer_dim>
+  auto &getTempBuffer(size_t Size, handler &CGH) {
+    auto Buffer = std::make_shared<buffer<_T, D>>(range<1>(Size));
+    CGH.addReduction(Buffer);
+    return *Buffer;
+  }
+
   /// Returns an accessor accessing the memory that will hold the reduction
   /// partial sums.
   /// If \p Size is equal to one, then the reduction result is the final and
@@ -665,15 +672,29 @@ public:
     return {*CounterBuf, CGH};
   }
 
-  RedOutVar &getUserRedVar() { return MRedOut; }
-
-  static inline result_type *getOutPointer(const rw_accessor_type &OutAcc) {
-    return OutAcc.get_pointer().get();
+  // On discrete (vs. integrated) GPUs it's faster to initialize memory with an
+  // extra kernel than copy it from the host.
+  template <typename Name> auto getGroupsCounterAccDiscrete(handler &CGH) {
+    auto &Buf = getTempBuffer<int, 1>(1, CGH);
+    std::shared_ptr<detail::queue_impl> QueueCopy = CGH.MQueue;
+    auto Event = CGH.withAuxHandler(QueueCopy, [&](handler &InitHandler) {
+      auto Acc = accessor{Buf, InitHandler, sycl::write_only, sycl::no_init};
+      InitHandler.single_task<Name>([=]() { Acc[0] = 0; });
+    });
+    CGH.depends_on(Event);
+    return accessor{Buf, CGH};
   }
+
+  RedOutVar &getUserRedVar() { return MRedOut; }
 
   static inline result_type *getOutPointer(result_type *OutPtr) {
     return OutPtr;
   }
+  template <class AccessorType>
+  static inline result_type *getOutPointer(const AccessorType &OutAcc) {
+    return OutAcc.get_pointer().get();
+  }
+
 
 private:
   template <typename BufferT>
@@ -865,7 +886,7 @@ template <class KernelName> struct RangeFastAtomics;
 } // namespace main_krn
 } // namespace reduction
 template <typename KernelName, typename KernelType, int Dims, class Reduction>
-void reduCGFuncForRangeFastAtomics(handler &CGH, KernelType KernelFunc,
+bool reduCGFuncForRangeFastAtomics(handler &CGH, KernelType KernelFunc,
                                    const range<Dims> &Range,
                                    const nd_range<1> &NDRange,
                                    Reduction &Redu) {
@@ -900,29 +921,37 @@ void reduCGFuncForRangeFastAtomics(handler &CGH, KernelType KernelFunc,
       Reducer.template atomic_combine(Reduction::getOutPointer(Out));
     }
   });
+  return Reduction::is_usm || Redu.initializeToIdentity();
 }
 
 namespace reduction {
 namespace main_krn {
 template <class KernelName> struct RangeFastReduce;
 } // namespace main_krn
+namespace init_krn {
+template <class KernelName> struct GroupCounter;
+}
 } // namespace reduction
 template <typename KernelName, typename KernelType, int Dims, class Reduction>
-void reduCGFuncForRangeFastReduce(handler &CGH, KernelType KernelFunc,
+bool reduCGFuncForRangeFastReduce(handler &CGH, KernelType KernelFunc,
                                   const range<Dims> &Range,
                                   const nd_range<1> &NDRange, Reduction &Redu) {
   constexpr size_t NElements = Reduction::num_elements;
   size_t WGSize = NDRange.get_local_range().size();
   size_t NWorkGroups = NDRange.get_group_range().size();
 
+  auto &Out = Redu.getUserRedVar();
+  if constexpr (Reduction::is_acc)
+    associateWithHandler(CGH, &Out, access::target::device);
+
+  auto &PartialSumsBuf = Redu.getTempBuffer(NWorkGroups * NElements, CGH);
+  accessor PartialSums(PartialSumsBuf, CGH, sycl::read_write, sycl::no_init);
+
   bool IsUpdateOfUserVar = !Reduction::is_usm && !Redu.initializeToIdentity();
-  auto PartialSums =
-      Redu.getWriteAccForPartialReds(NWorkGroups * NElements, CGH);
-  auto Out = (NWorkGroups == 1)
-                 ? PartialSums
-                 : Redu.getWriteAccForPartialReds(NElements, CGH);
+  using InitName =
+      __sycl_reduction_kernel<reduction::init_krn::GroupCounter, KernelName>;
   auto NWorkGroupsFinished =
-      Redu.getReadWriteAccessorToInitializedGroupsCounter(CGH);
+      Redu.template getGroupsCounterAccDiscrete<InitName>(CGH);
   auto DoReducePartialSumsInLastWG =
       Reduction::template getReadWriteLocalAcc<int>(1, CGH);
 
@@ -940,20 +969,25 @@ void reduCGFuncForRangeFastReduce(handler &CGH, KernelType KernelFunc,
     // reduce_over_group is only defined for each T, not for span<T, ...>
     size_t LID = NDId.get_local_id(0);
     for (int E = 0; E < NElements; ++E) {
-      Reducer.getElement(E) =
-          reduce_over_group(Group, Reducer.getElement(E), BOp);
-
+      auto &RedElem = Reducer.getElement(E);
+      RedElem = reduce_over_group(Group, RedElem, BOp);
       if (LID == 0) {
-        if (NWorkGroups == 1 && IsUpdateOfUserVar)
-          Reducer.getElement(E) =
-              BOp(Reducer.getElement(E), Reduction::getOutPointer(Out)[E]);
-
-        // if NWorkGroups == 1, then PartialsSum and Out point to same memory.
-        Reduction::getOutPointer(
-            PartialSums)[NDId.get_group_linear_id() * NElements + E] =
-            Reducer.getElement(E);
+        if (NWorkGroups == 1) {
+          auto &OutElem = Reduction::getOutPointer(Out)[E];
+          // Can avoid using partial sum and write the final result immediately.
+          if (IsUpdateOfUserVar)
+            RedElem = BOp(RedElem, OutElem);
+          OutElem = RedElem;
+        } else {
+          PartialSums[NDId.get_group_linear_id() * NElements + E] =
+              Reducer.getElement(E);
+        }
       }
     }
+
+    if (NWorkGroups == 1)
+      // We're done.
+      return;
 
     // Signal this work-group has finished after all values are reduced
     if (LID == 0) {
@@ -961,29 +995,31 @@ void reduCGFuncForRangeFastReduce(handler &CGH, KernelType KernelFunc,
           sycl::atomic_ref<int, memory_order::relaxed, memory_scope::device,
                            access::address_space::global_space>(
               NWorkGroupsFinished[0]);
-      DoReducePartialSumsInLastWG[0] =
-          ++NFinished == NWorkGroups && NWorkGroups > 1;
+      DoReducePartialSumsInLastWG[0] = ++NFinished == NWorkGroups;
     }
 
     sycl::detail::workGroupBarrier();
     if (DoReducePartialSumsInLastWG[0]) {
       // Reduce each result separately
-      // TODO: Opportunity to parallelize across elements
+      // TODO: Opportunity to parallelize across elements.
       for (int E = 0; E < NElements; ++E) {
+        auto &OutElem = Reduction::getOutPointer(Out)[E];
         auto LocalSum = Reducer.getIdentity();
         for (size_t I = LID; I < NWorkGroups; I += WGSize)
           LocalSum = BOp(LocalSum, PartialSums[I * NElements + E]);
-        Reducer.getElement(E) = reduce_over_group(Group, LocalSum, BOp);
+        auto Result = reduce_over_group(Group, LocalSum, BOp);
 
         if (LID == 0) {
           if (IsUpdateOfUserVar)
-            Reducer.getElement(E) =
-                BOp(Reducer.getElement(E), Reduction::getOutPointer(Out)[E]);
-          Reduction::getOutPointer(Out)[E] = Reducer.getElement(E);
+            Result = BOp(Result, OutElem);
+          OutElem = Result;
         }
       }
     }
   });
+
+  // We've updated user's variable, no extra work needed.
+  return false;
 }
 
 namespace reduction {
@@ -992,7 +1028,7 @@ template <class KernelName> struct RangeBasic;
 } // namespace main_krn
 } // namespace reduction
 template <typename KernelName, typename KernelType, int Dims, class Reduction>
-void reduCGFuncForRangeBasic(handler &CGH, KernelType KernelFunc,
+bool reduCGFuncForRangeBasic(handler &CGH, KernelType KernelFunc,
                              const range<Dims> &Range,
                              const nd_range<1> &NDRange, Reduction &Redu) {
   constexpr size_t NElements = Reduction::num_elements;
@@ -1098,10 +1134,13 @@ void reduCGFuncForRangeBasic(handler &CGH, KernelType KernelFunc,
       }
     }
   });
+  return Reduction::is_usm || Reduction::is_dw_acc;
 }
 
+/// Returns "true" if the result has to be saved to user's variable by
+/// reduSaveFinalResultToUserMem.
 template <typename KernelName, typename KernelType, int Dims, class Reduction>
-void reduCGFuncForRange(handler &CGH, KernelType KernelFunc,
+bool reduCGFuncForRange(handler &CGH, KernelType KernelFunc,
                         const range<Dims> &Range, size_t MaxWGSize,
                         uint32_t NumConcurrentWorkGroups, Reduction &Redu) {
   size_t NWorkItems = Range.size();
@@ -1114,16 +1153,15 @@ void reduCGFuncForRange(handler &CGH, KernelType KernelFunc,
   size_t NDRItems = NWorkGroups * WGSize;
   nd_range<1> NDRange{range<1>{NDRItems}, range<1>{WGSize}};
 
-  if constexpr (Reduction::has_fast_atomics) {
-    reduCGFuncForRangeFastAtomics<KernelName>(CGH, KernelFunc, Range, NDRange,
-                                              Redu);
+  if constexpr (Reduction::has_fast_atomics)
+    return reduCGFuncForRangeFastAtomics<KernelName>(CGH, KernelFunc, Range,
+                                                     NDRange, Redu);
 
-  } else if constexpr (Reduction::has_fast_reduce) {
-    reduCGFuncForRangeFastReduce<KernelName>(CGH, KernelFunc, Range, NDRange,
+  if constexpr (Reduction::has_fast_reduce)
+    return reduCGFuncForRangeFastReduce<KernelName>(CGH, KernelFunc, Range,
+                                                    NDRange, Redu);
+  return reduCGFuncForRangeBasic<KernelName>(CGH, KernelFunc, Range, NDRange,
                                              Redu);
-  } else {
-    reduCGFuncForRangeBasic<KernelName>(CGH, KernelFunc, Range, NDRange, Redu);
-  }
 }
 
 namespace reduction {

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -568,11 +568,13 @@ public:
   static constexpr bool has_fast_reduce =
       IsReduOptForFastReduce<T, BinaryOperation>::value;
 
-  static constexpr bool my_is_usm = std::is_same_v<RedOutVar, T *>;
-  static constexpr bool is_usm = my_is_usm;
+  static constexpr bool is_usm = std::is_same_v<RedOutVar, T *>;
 
-  static constexpr bool my_is_rw_acc = is_rw_acc_t<RedOutVar>::value;
-  static constexpr bool my_is_dw_acc = is_dw_acc_t<RedOutVar>::value;
+  static constexpr bool is_rw_acc = is_rw_acc_t<RedOutVar>::value;
+  static constexpr bool is_dw_acc = is_dw_acc_t<RedOutVar>::value;
+  static constexpr bool is_acc = is_rw_acc | is_dw_acc;
+  static_assert(!is_rw_acc || !is_dw_acc, "Can be only one at once!");
+  static_assert(!is_usm || !is_acc, "Ca be only one at once!");
 
   static constexpr size_t dims = Dims;
   static constexpr size_t num_elements = Extent;
@@ -585,8 +587,7 @@ public:
   /// to keep the accessor alive until the command group finishes the work.
   /// This function does not do anything for USM reductions.
   void associateWithHandler(handler &CGH) {
-    if constexpr (!my_is_usm) {
-      static_assert(my_is_rw_acc || my_is_dw_acc);
+    if constexpr (is_acc) {
       CGH.associateWithHandler(&MRedOut, access::target::device);
     }
   }
@@ -621,7 +622,7 @@ public:
   template <bool IsOneWG, bool _IsUSM = is_usm>
   std::enable_if_t<IsOneWG && !_IsUSM, rw_accessor_type>
   getWriteMemForPartialReds(size_t, handler &CGH) {
-    if constexpr (my_is_rw_acc)
+    if constexpr (is_rw_acc)
       return MRedOut;
     return getWriteMemForPartialReds<false>(1, CGH);
   }
@@ -643,7 +644,7 @@ public:
   /// Otherwise, a new buffer is created and accessor to that buffer is
   /// returned.
   rw_accessor_type getWriteAccForPartialReds(size_t Size, handler &CGH) {
-    if constexpr (my_is_rw_acc) {
+    if constexpr (is_rw_acc) {
       if (Size == 1) {
         associateWithHandler(CGH);
         return MRedOut;
@@ -663,11 +664,11 @@ public:
   template <bool HasFastAtomics = (has_fast_atomics || has_atomic_add_float64)>
   std::enable_if_t<HasFastAtomics, rw_accessor_type>
   getReadWriteAccessorToInitializedMem(handler &CGH) {
-    if constexpr (my_is_rw_acc) {
+    if constexpr (is_rw_acc) {
       if (!base::initializeToIdentity())
         return MRedOut;
     }
-    assert(!(my_is_dw_acc && !base::initializeToIdentity()) &&
+    assert(!(is_dw_acc && !base::initializeToIdentity()) &&
            "Unexpected condition!");
 
     // TODO: Move to T[] in C++20 to simplify handling here
@@ -706,20 +707,21 @@ public:
   }
 
 private:
-  template <typename BufferT, typename _self = self>
-  std::enable_if_t<_self::is_placeholder == access::placeholder::false_t,
-                   rw_accessor_type>
-  createHandlerWiredReadWriteAccessor(handler &CGH, BufferT Buffer) {
-    return {Buffer, CGH};
-  }
-
-  template <typename BufferT, typename _self = self>
-  std::enable_if_t<_self::is_placeholder == access::placeholder::true_t,
-                   rw_accessor_type>
-  createHandlerWiredReadWriteAccessor(handler &CGH, BufferT Buffer) {
-    rw_accessor_type Acc(Buffer);
-    CGH.require(Acc);
-    return Acc;
+  template <typename BufferT>
+  rw_accessor_type createHandlerWiredReadWriteAccessor(handler &CGH,
+                                                       BufferT Buffer) {
+    // TODO:
+    // SYCL 2020: The accessor template parameter IsPlaceholder is allowed to be
+    // specified, but it has no bearing on whether the accessor instance is a
+    // placeholder. This is determined solely by the constructor used to create
+    // the instance. The associated type access::placeholder is also deprecated.
+    if constexpr (is_placeholder == access::placeholder::true_t) {
+      rw_accessor_type Acc(Buffer);
+      CGH.require(Acc);
+      return Acc;
+    } else {
+      return {Buffer, CGH};
+    }
   }
 
   std::shared_ptr<buffer<T, buffer_dim>> MOutBufPtr;
@@ -780,9 +782,10 @@ private:
   }
 
 public:
-  using algo::my_is_usm;
-  using algo::my_is_rw_acc;
-  using algo::my_is_dw_acc;
+  using algo::is_usm;
+  using algo::is_rw_acc;
+  using algo::is_dw_acc;
+  using algo::is_acc;
 
   using reducer_type = typename algo::reducer_type;
   using rw_accessor_type = typename algo::rw_accessor_type;
@@ -792,8 +795,7 @@ public:
 
   /// Constructs reduction_impl when the identity value is statically known.
   template <typename _self = self,
-            enable_if_t<_self::is_known_identity &&
-                        (my_is_rw_acc || my_is_dw_acc)> * = nullptr>
+            enable_if_t<_self::is_known_identity && _self::is_acc> * = nullptr>
   reduction_impl(RedOutVar &Acc)
       : algo(reducer_type::getIdentity(), BinaryOperation(), false, Acc) {
     if (Acc.size() != 1)
@@ -807,7 +809,7 @@ public:
   /// reduction value is added using BinaryOperation, i.e. it is expected that
   /// the memory is pre-initialized with some meaningful value.
   template <typename _self = self, enable_if_t<_self::is_known_identity &&
-                                               _self::my_is_usm> * = nullptr>
+                                               _self::is_usm> * = nullptr>
   reduction_impl(RedOutVar VarPtr, bool InitializeToIdentity = false)
       : algo(reducer_type::getIdentity(), BinaryOperation(),
              InitializeToIdentity, VarPtr) {}
@@ -815,8 +817,8 @@ public:
   /// SYCL-2020.
   /// Constructs reduction_impl when the identity value is statically known.
   template <typename _self = self,
-            std::enable_if_t<_self::is_known_identity && _self::my_is_rw_acc>
-                * = nullptr>
+            std::enable_if_t<_self::is_known_identity && _self::is_rw_acc> * =
+                nullptr>
   reduction_impl(RedOutVar &Acc, handler &CGH, bool InitializeToIdentity)
       : algo(reducer_type::getIdentity(), BinaryOperation(),
              InitializeToIdentity, Acc) {
@@ -828,10 +830,9 @@ public:
   }
 
   /// Constructs reduction_impl when the identity value is unknown.
-  template <typename _self = self,
-            enable_if_t<_self::my_is_rw_acc || _self::my_is_dw_acc> * = nullptr>
+  template <typename _self = self, enable_if_t<_self::is_acc> * = nullptr>
   reduction_impl(RedOutVar &Acc, const T &Identity, BinaryOperation BOp)
-      : algo(chooseIdentity(Identity), BOp, my_is_dw_acc, Acc) {
+      : algo(chooseIdentity(Identity), BOp, is_dw_acc, Acc) {
     if (Acc.size() != 1)
       throw sycl::runtime_error(errc::invalid,
                                 "Reduction variable must be a scalar.",
@@ -841,13 +842,13 @@ public:
   /// The \param VarPtr is a USM pointer to memory, to where the computed
   /// reduction value is added using BinaryOperation, i.e. it is expected that
   /// the memory is pre-initialized with some meaningful value.
-  template <typename _self = self, enable_if_t<_self::my_is_usm> * = nullptr>
+  template <typename _self = self, enable_if_t<_self::is_usm> * = nullptr>
   reduction_impl(RedOutVar VarPtr, const T &Identity, BinaryOperation BOp,
                  bool InitializeToIdentity = false)
       : algo(chooseIdentity(Identity), BOp, InitializeToIdentity, VarPtr) {}
 
   /// For placeholder accessor.
-  template <typename _self = self, enable_if_t<_self::my_is_rw_acc> * = nullptr>
+  template <typename _self = self, enable_if_t<_self::is_rw_acc> * = nullptr>
   reduction_impl(RedOutVar &Acc, handler &CGH, const T &Identity,
                  BinaryOperation BOp, bool InitializeToIdentity)
       : algo(chooseIdentity(Identity), BOp, InitializeToIdentity, Acc) {
@@ -2385,7 +2386,7 @@ template <typename Reduction, typename... RestT>
 void reduSaveFinalResultToUserMemHelper(
     std::vector<event> &Events, std::shared_ptr<detail::queue_impl> Queue,
     bool IsHost, Reduction &Redu, RestT... Rest) {
-  if constexpr (Reduction::my_is_dw_acc) {
+  if constexpr (Reduction::is_dw_acc) {
     event CopyEvent =
         handler::withAuxHandler(Queue, IsHost, [&](handler &CopyHandler) {
           auto InAcc = Redu.getReadAccToPreviousPartialReds(CopyHandler);

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -578,15 +578,6 @@ public:
                       RedOutVar RedOut)
       : base(Identity, BinaryOp, Init), MRedOut(std::move(RedOut)){};
 
-  /// Associates the reduction accessor to user's memory with \p CGH handler
-  /// to keep the accessor alive until the command group finishes the work.
-  /// This function does not do anything for USM reductions.
-  void associateWithHandler(handler &CGH) {
-    if constexpr (is_acc) {
-      CGH.associateWithHandler(&MRedOut, access::target::device);
-    }
-  }
-
   /// Creates and returns a local accessor with the \p Size elements.
   /// By default the local accessor elements are of the same type as the
   /// elements processed by the reduction, but may it be altered by specifying
@@ -624,7 +615,7 @@ public:
   rw_accessor_type getWriteAccForPartialReds(size_t Size, handler &CGH) {
     if constexpr (is_rw_acc) {
       if (Size == 1) {
-        associateWithHandler(CGH);
+        CGH.associateWithHandler(&MRedOut, access::target::device);
         return MRedOut;
       }
     }
@@ -800,7 +791,7 @@ public:
   reduction_impl(RedOutVar &Acc, handler &CGH, bool InitializeToIdentity)
       : algo(reducer_type::getIdentity(), BinaryOperation(),
              InitializeToIdentity, Acc) {
-    algo::associateWithHandler(CGH);
+    associateWithHandler(CGH, &Acc, access::target::device);
     if (Acc.size() != 1)
       throw sycl::runtime_error(errc::invalid,
                                 "Reduction variable must be a scalar.",
@@ -830,7 +821,7 @@ public:
   reduction_impl(RedOutVar &Acc, handler &CGH, const T &Identity,
                  BinaryOperation BOp, bool InitializeToIdentity)
       : algo(chooseIdentity(Identity), BOp, InitializeToIdentity, Acc) {
-    algo::associateWithHandler(CGH);
+    associateWithHandler(CGH, &Acc, access::target::device);
     if (Acc.size() != 1)
       throw sycl::runtime_error(errc::invalid,
                                 "Reduction variable must be a scalar.",
@@ -1553,7 +1544,7 @@ template <typename KernelName, class Reduction>
 std::enable_if_t<!Reduction::is_usm>
 reduSaveFinalResultToUserMem(handler &CGH, Reduction &Redu) {
   auto InAcc = Redu.getReadAccToPreviousPartialReds(CGH);
-  Redu.associateWithHandler(CGH);
+  associateWithHandler(CGH, &Redu.getUserRedVar(), access::target::device);
   CGH.copy(InAcc, Redu.getUserRedVar());
 }
 
@@ -2081,26 +2072,16 @@ void reduCGFuncAtomic64(handler &CGH, KernelType KernelFunc,
       CGH, KernelFunc, Range, Redu, Out);
 }
 
-inline void associateReduAccsWithHandlerHelper(handler &) {}
-
-template <typename ReductionT>
-void associateReduAccsWithHandlerHelper(handler &CGH, ReductionT &Redu) {
-  Redu.associateWithHandler(CGH);
-}
-
-template <typename ReductionT, typename... RestT,
-          enable_if_t<(sizeof...(RestT) > 0), int> Z = 0>
-void associateReduAccsWithHandlerHelper(handler &CGH, ReductionT &Redu,
-                                        RestT &...Rest) {
-  Redu.associateWithHandler(CGH);
-  associateReduAccsWithHandlerHelper(CGH, Rest...);
-}
-
 template <typename... Reductions, size_t... Is>
 void associateReduAccsWithHandler(handler &CGH,
                                   std::tuple<Reductions...> &ReduTuple,
                                   std::index_sequence<Is...>) {
-  associateReduAccsWithHandlerHelper(CGH, std::get<Is>(ReduTuple)...);
+  auto ProcessOne = [&CGH](auto Redu) {
+    if constexpr (decltype(Redu)::is_acc) {
+      associateWithHandler(CGH, &Redu.getUserRedVar(), access::target::device);
+    }
+  };
+  (ProcessOne(std::get<Is>(ReduTuple)), ...);
 }
 
 /// All scalar reductions are processed together; there is one loop of log2(N)
@@ -2371,7 +2352,8 @@ void reduSaveFinalResultToUserMemHelper(
         handler::withAuxHandler(Queue, IsHost, [&](handler &CopyHandler) {
           auto InAcc = Redu.getReadAccToPreviousPartialReds(CopyHandler);
           auto OutAcc = Redu.getUserRedVar();
-          Redu.associateWithHandler(CopyHandler);
+          associateWithHandler(CopyHandler, &Redu.getUserRedVar(),
+                               access::target::device);
           if (!Events.empty())
             CopyHandler.depends_on(Events.back());
           CopyHandler.copy(InAcc, OutAcc);

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -530,11 +530,6 @@ class reduction_impl_algo<
       T, BinaryOperation, Dims, Extent, RedOutVar,
       default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>>;
 
-protected:
-  static constexpr bool my_is_usm = std::is_same_v<RedOutVar, T *>;
-  static constexpr bool my_is_rw_acc = is_rw_acc_t<RedOutVar>::value;
-  static constexpr bool my_is_dw_acc = is_dw_acc_t<RedOutVar>::value;
-
 public:
   using reducer_type = reducer<T, BinaryOperation, Dims, Extent>;
   using result_type = T;
@@ -560,7 +555,14 @@ public:
       IsReduOptForFastAtomicFetch<T, BinaryOperation>::value;
   static constexpr bool has_fast_reduce =
       IsReduOptForFastReduce<T, BinaryOperation>::value;
+
   static constexpr bool is_usm = IsUSM;
+  static constexpr bool my_is_usm = std::is_same_v<RedOutVar, T *>;
+  static_assert(is_usm == my_is_usm);
+
+  static constexpr bool my_is_rw_acc = is_rw_acc_t<RedOutVar>::value;
+  static constexpr bool my_is_dw_acc = is_dw_acc_t<RedOutVar>::value;
+
   static constexpr bool is_placeholder =
       (IsPlaceholder == access::placeholder::true_t);
 
@@ -589,10 +591,10 @@ public:
   /// to keep the accessor alive until the command group finishes the work.
   /// This function does not do anything for USM reductions.
   void associateWithHandler(handler &CGH) {
-    if (MRWAcc)
-      CGH.associateWithHandler(MRWAcc.get(), access::target::device);
-    else if (MDWAcc)
-      CGH.associateWithHandler(MDWAcc.get(), access::target::device);
+    if constexpr (!my_is_usm) {
+      static_assert(my_is_rw_acc || my_is_dw_acc);
+      CGH.associateWithHandler(&MRedOut, access::target::device);
+    }
   }
 
   /// Creates and returns a local accessor with the \p Size elements.
@@ -616,7 +618,7 @@ public:
   template <bool IsOneWG, bool _IsUSM = is_usm>
   std::enable_if_t<IsOneWG && _IsUSM, result_type *>
   getWriteMemForPartialReds(size_t, handler &) {
-    return getUSMPointer();
+    return getUserRedVar();
   }
 
   /// Returns user's accessor passed to reduction for editing if that is
@@ -625,8 +627,8 @@ public:
   template <bool IsOneWG, bool _IsUSM = is_usm>
   std::enable_if_t<IsOneWG && !_IsUSM, rw_accessor_type>
   getWriteMemForPartialReds(size_t, handler &CGH) {
-    if (MRWAcc)
-      return *MRWAcc;
+    if constexpr (my_is_rw_acc)
+      return MRedOut;
     return getWriteMemForPartialReds<false>(1, CGH);
   }
 
@@ -647,9 +649,11 @@ public:
   /// Otherwise, a new buffer is created and accessor to that buffer is
   /// returned.
   rw_accessor_type getWriteAccForPartialReds(size_t Size, handler &CGH) {
-    if (Size == 1 && MRWAcc != nullptr) {
-      associateWithHandler(CGH);
-      return *MRWAcc;
+    if constexpr (my_is_rw_acc) {
+      if (Size == 1) {
+        associateWithHandler(CGH);
+        return MRedOut;
+      }
     }
 
     // Create a new output buffer and return an accessor to it.
@@ -665,8 +669,12 @@ public:
   template <bool HasFastAtomics = (has_fast_atomics || has_atomic_add_float64)>
   std::enable_if_t<HasFastAtomics, rw_accessor_type>
   getReadWriteAccessorToInitializedMem(handler &CGH) {
-    if (!is_usm && !base::initializeToIdentity())
-      return *MRWAcc;
+    if constexpr (my_is_rw_acc) {
+      if (!base::initializeToIdentity())
+        return MRedOut;
+    }
+    assert(!(my_is_dw_acc && !base::initializeToIdentity()) &&
+           "Unexpected condition!");
 
     // TODO: Move to T[] in C++20 to simplify handling here
     // auto RWReduVal = std::make_shared<T[num_elements]>();
@@ -693,22 +701,7 @@ public:
     return {*CounterBuf, CGH};
   }
 
-  bool hasUserDiscardWriteAccessor() { return MDWAcc != nullptr; }
-
-  template <bool _IsUSM = IsUSM>
-  std::enable_if_t<!_IsUSM, rw_accessor_type &> getUserReadWriteAccessor() {
-    return *MRWAcc;
-  }
-
-  template <bool _IsUSM = IsUSM>
-  std::enable_if_t<!_IsUSM, dw_accessor_type &> getUserDiscardWriteAccessor() {
-    return *MDWAcc;
-  }
-
-  result_type *getUSMPointer() {
-    assert(is_usm && "Unexpected call of getUSMPointer().");
-    return MUSMPointer;
-  }
+  RedOutVar &getUserRedVar() { return MRedOut; }
 
   static inline result_type *getOutPointer(const rw_accessor_type &OutAcc) {
     return OutAcc.get_pointer().get();
@@ -773,11 +766,11 @@ private:
   using algo = reduction_impl_algo<T, BinaryOperation, Dims, Extent, RedOutVar,
                                    Algorithm>;
 
+public:
   using algo::my_is_usm;
   using algo::my_is_rw_acc;
   using algo::my_is_dw_acc;
 
-public:
   using reducer_type = typename algo::reducer_type;
   using rw_accessor_type = typename algo::rw_accessor_type;
   using dw_accessor_type = typename algo::dw_accessor_type;
@@ -1738,10 +1731,7 @@ std::enable_if_t<!Reduction::is_usm>
 reduSaveFinalResultToUserMem(handler &CGH, Reduction &Redu) {
   auto InAcc = Redu.getReadAccToPreviousPartialReds(CGH);
   Redu.associateWithHandler(CGH);
-  if (Redu.hasUserDiscardWriteAccessor())
-    CGH.copy(InAcc, Redu.getUserDiscardWriteAccessor());
-  else
-    CGH.copy(InAcc, Redu.getUserReadWriteAccessor());
+  CGH.copy(InAcc, Redu.getUserRedVar());
 }
 
 // This method is used for implementation of parallel_for accepting 1 reduction.
@@ -1754,7 +1744,7 @@ std::enable_if_t<Reduction::is_usm>
 reduSaveFinalResultToUserMem(handler &CGH, Reduction &Redu) {
   constexpr size_t NElements = Reduction::num_elements;
   auto InAcc = Redu.getReadAccToPreviousPartialReds(CGH);
-  auto UserVarPtr = Redu.getUSMPointer();
+  auto UserVarPtr = Redu.getUserRedVar();
   bool IsUpdateOfUserVar = !Redu.initializeToIdentity();
   auto BOp = Redu.getBinaryOperation();
   CGH.single_task<KernelName>([=] {
@@ -2551,21 +2541,17 @@ template <typename Reduction, typename... RestT>
 void reduSaveFinalResultToUserMemHelper(
     std::vector<event> &Events, std::shared_ptr<detail::queue_impl> Queue,
     bool IsHost, Reduction &Redu, RestT... Rest) {
-  // Reductions initialized with USM pointer currently do not require copying
-  // because the last kernel writes directly to the USM memory.
-  if constexpr (!Reduction::is_usm) {
-    if (Redu.hasUserDiscardWriteAccessor()) {
-      event CopyEvent =
-          handler::withAuxHandler(Queue, IsHost, [&](handler &CopyHandler) {
-            auto InAcc = Redu.getReadAccToPreviousPartialReds(CopyHandler);
-            auto OutAcc = Redu.getUserDiscardWriteAccessor();
-            Redu.associateWithHandler(CopyHandler);
-            if (!Events.empty())
-              CopyHandler.depends_on(Events.back());
-            CopyHandler.copy(InAcc, OutAcc);
-          });
-      Events.push_back(CopyEvent);
-    }
+  if constexpr (Reduction::my_is_dw_acc) {
+    event CopyEvent =
+        handler::withAuxHandler(Queue, IsHost, [&](handler &CopyHandler) {
+          auto InAcc = Redu.getReadAccToPreviousPartialReds(CopyHandler);
+          auto OutAcc = Redu.getUserRedVar();
+          Redu.associateWithHandler(CopyHandler);
+          if (!Events.empty())
+            CopyHandler.depends_on(Events.back());
+          CopyHandler.copy(InAcc, OutAcc);
+        });
+    Events.push_back(CopyEvent);
   }
   reduSaveFinalResultToUserMemHelper(Events, Queue, IsHost, Rest...);
 }

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -604,32 +604,15 @@ public:
     return {*MOutBufPtr, CGH};
   }
 
-  /// Returns user's USM pointer passed to reduction for editing.
-  template <bool IsOneWG, bool _IsUSM = is_usm>
-  std::enable_if_t<IsOneWG && _IsUSM, result_type *>
-  getWriteMemForPartialReds(size_t, handler &) {
-    return getUserRedVar();
-  }
-
-  /// Returns user's accessor passed to reduction for editing if that is
-  /// the read-write accessor. Otherwise, create a new buffer and return
-  /// read-write accessor to it.
-  template <bool IsOneWG, bool _IsUSM = is_usm>
-  std::enable_if_t<IsOneWG && !_IsUSM, rw_accessor_type>
-  getWriteMemForPartialReds(size_t, handler &CGH) {
-    if constexpr (is_rw_acc)
-      return MRedOut;
-    return getWriteMemForPartialReds<false>(1, CGH);
-  }
-
-  /// Constructs a new temporary buffer to hold partial sums and returns
-  /// the accessor for that buffer.
   template <bool IsOneWG>
-  std::enable_if_t<!IsOneWG, rw_accessor_type>
-  getWriteMemForPartialReds(size_t Size, handler &CGH) {
-    MOutBufPtr = std::make_shared<buffer<T, buffer_dim>>(range<1>(Size));
-    CGH.addReduction(MOutBufPtr);
-    return createHandlerWiredReadWriteAccessor(CGH, *MOutBufPtr);
+  auto getWriteMemForPartialReds(size_t Size, handler &CGH) {
+    if constexpr (IsOneWG && !is_dw_acc) {
+      return MRedOut;
+    } else {
+      MOutBufPtr = std::make_shared<buffer<T, buffer_dim>>(range<1>(Size));
+      CGH.addReduction(MOutBufPtr);
+      return createHandlerWiredReadWriteAccessor(CGH, *MOutBufPtr);
+    }
   }
 
   /// Returns an accessor accessing the memory that will hold the reduction

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -488,6 +488,24 @@ protected:
   bool InitializeToIdentity;
 };
 
+template <class T>
+struct is_rw_acc_t : public std::false_type {};
+
+template <class T, int AccessorDims, access::placeholder IsPlaceholder>
+struct is_rw_acc_t<
+    accessor<T, AccessorDims, access::mode::read_write, access::target::device,
+             IsPlaceholder, ext::oneapi::accessor_property_list<>>>
+    : public std::true_type {};
+
+template <class T>
+struct is_dw_acc_t : public std::false_type {};
+
+template <class T, int AccessorDims, access::placeholder IsPlaceholder>
+struct is_dw_acc_t<accessor<T, AccessorDims, access::mode::discard_write,
+                            access::target::device, IsPlaceholder,
+                            ext::oneapi::accessor_property_list<>>>
+    : public std::true_type {};
+
 /// Types representing specific reduction algorithms
 /// Enables reduction_impl_algo to take additional algorithm-specific templates
 template <bool IsUSM, access::placeholder IsPlaceholder, int AccessorDims>
@@ -508,6 +526,11 @@ class reduction_impl_algo<
     default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>>
     : public reduction_impl_common<T, BinaryOperation> {
   using base = reduction_impl_common<T, BinaryOperation>;
+
+protected:
+  static constexpr bool my_is_usm = std::is_same_v<RedOutVar, T *>;
+  static constexpr bool my_is_rw_acc = is_rw_acc_t<RedOutVar>::value;
+  static constexpr bool my_is_dw_acc = is_dw_acc_t<RedOutVar>::value;
 
 public:
   using reducer_type = reducer<T, BinaryOperation, Dims, Extent>;
@@ -726,24 +749,6 @@ template <typename T> struct AreAllButLastReductions<T> {
   static constexpr bool value =
       !std::is_base_of<reduction_impl_base, std::remove_reference_t<T>>::value;
 };
-template <class T>
-struct is_rw_acc_t : public std::false_type {};
-
-template <class T, int AccessorDims, access::placeholder IsPlaceholder>
-struct is_rw_acc_t<
-    accessor<T, AccessorDims, access::mode::read_write, access::target::device,
-             IsPlaceholder, ext::oneapi::accessor_property_list<>>>
-    : public std::true_type {};
-
-template <class T>
-struct is_dw_acc_t : public std::false_type {};
-
-template <class T, int AccessorDims, access::placeholder IsPlaceholder>
-struct is_dw_acc_t<accessor<T, AccessorDims, access::mode::discard_write,
-                            access::target::device, IsPlaceholder,
-                            ext::oneapi::accessor_property_list<>>>
-    : public std::true_type {};
-
 /// This class encapsulates the reduction variable/accessor,
 /// the reduction operator and an optional operator identity.
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
@@ -755,9 +760,10 @@ class reduction_impl
 private:
   using algo = reduction_impl_algo<T, BinaryOperation, Dims, Extent, RedOutVar,
                                    Algorithm>;
-  static constexpr bool my_is_usm = std::is_same_v<RedOutVar, T *>;
-  static constexpr bool my_is_rw_acc = is_rw_acc_t<RedOutVar>::value;
-  static constexpr bool my_is_dw_acc = is_dw_acc_t<RedOutVar>::value;
+
+  using algo::my_is_usm;
+  using algo::my_is_rw_acc;
+  using algo::my_is_dw_acc;
 
 public:
   using reducer_type = typename algo::reducer_type;

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -508,7 +508,7 @@ struct is_dw_acc_t<accessor<T, AccessorDims, access::mode::discard_write,
 
 /// Types representing specific reduction algorithms
 /// Enables reduction_impl_algo to take additional algorithm-specific templates
-template <bool IsUSM, access::placeholder IsPlaceholder, int AccessorDims>
+template <access::placeholder IsPlaceholder, int AccessorDims>
 class default_reduction_algorithm {};
 
 /// Templated class for implementations of specific reduction algorithms
@@ -519,17 +519,16 @@ class reduction_impl_algo;
 /// Original reduction algorithm is the default. It supports both USM and
 /// accessors via a single class
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          bool IsUSM, access::placeholder IsPlaceholder, int AccessorDims,
+          access::placeholder IsPlaceholder, int AccessorDims,
           typename RedOutVar>
 class reduction_impl_algo<
     T, BinaryOperation, Dims, Extent,
-    default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>, RedOutVar>
+    default_reduction_algorithm<IsPlaceholder, AccessorDims>, RedOutVar>
     : public reduction_impl_common<T, BinaryOperation> {
   using base = reduction_impl_common<T, BinaryOperation>;
   using self = reduction_impl_algo<
       T, BinaryOperation, Dims, Extent,
-      default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>,
-      RedOutVar>;
+      default_reduction_algorithm<IsPlaceholder, AccessorDims>, RedOutVar>;
 
 public:
   using reducer_type = reducer<T, BinaryOperation, Dims, Extent>;
@@ -557,9 +556,8 @@ public:
   static constexpr bool has_fast_reduce =
       IsReduOptForFastReduce<T, BinaryOperation>::value;
 
-  static constexpr bool is_usm = IsUSM;
   static constexpr bool my_is_usm = std::is_same_v<RedOutVar, T *>;
-  static_assert(is_usm == my_is_usm);
+  static constexpr bool is_usm = my_is_usm;
 
   static constexpr bool my_is_rw_acc = is_rw_acc_t<RedOutVar>::value;
   static constexpr bool my_is_dw_acc = is_dw_acc_t<RedOutVar>::value;
@@ -2459,7 +2457,7 @@ tuple_select_elements(TupleT Tuple, std::index_sequence<Is...>) {
 template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
           access::placeholder IsPH>
 detail::reduction_impl<T, BinaryOperation, 0, 1,
-                       detail::default_reduction_algorithm<false, IsPH, Dims>,
+                       detail::default_reduction_algorithm<IsPH, Dims>,
                        accessor<T, Dims, AccMode, access::target::device, IsPH>>
 reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
           const T &Identity, BinaryOperation BOp) {
@@ -2475,7 +2473,7 @@ template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
 std::enable_if_t<sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
                  detail::reduction_impl<
                      T, BinaryOperation, 0, 1,
-                     detail::default_reduction_algorithm<false, IsPH, Dims>,
+                     detail::default_reduction_algorithm<IsPH, Dims>,
                      accessor<T, Dims, AccMode, access::target::device, IsPH>>>
 reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
           BinaryOperation) {
@@ -2489,8 +2487,7 @@ reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
 template <typename T, class BinaryOperation>
 detail::reduction_impl<
     T, BinaryOperation, 0, 1,
-    detail::default_reduction_algorithm<true, access::placeholder::false_t, 1>,
-    T *>
+    detail::default_reduction_algorithm<access::placeholder::false_t, 1>, T *>
 reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
   return {VarPtr, Identity, BOp};
 }
@@ -2501,12 +2498,11 @@ reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
 /// operation used in the reduction.
 /// The identity value is not passed to this version as it is statically known.
 template <typename T, class BinaryOperation>
-std::enable_if_t<
-    sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
-    detail::reduction_impl<T, BinaryOperation, 0, 1,
-                           detail::default_reduction_algorithm<
-                               true, access::placeholder::false_t, 1>,
-                           T *>>
+std::enable_if_t<sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
+                 detail::reduction_impl<T, BinaryOperation, 0, 1,
+                                        detail::default_reduction_algorithm<
+                                            access::placeholder::false_t, 1>,
+                                        T *>>
 reduction(T *VarPtr, BinaryOperation) {
   return {VarPtr};
 }

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -744,6 +744,32 @@ class reduction_impl
 private:
   using algo = reduction_impl_algo<T, BinaryOperation, Dims, Extent, RedOutVar,
                                    Algorithm>;
+  using self = reduction_impl<T, BinaryOperation, Dims, Extent, RedOutVar, Algorithm>;
+
+  static constexpr bool is_known_identity =
+      sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value;
+
+  // TODO: Do we also need chooseBinOp?
+  static constexpr T chooseIdentity(const T &Identity) {
+    // For now the implementation ignores the identity value given by user
+    // when the implementation knows the identity.
+    // The SPEC could prohibit passing identity parameter to operations with
+    // known identity, but that could have some bad consequences too.
+    // For example, at some moment the implementation may NOT know the identity
+    // for COMPLEX-PLUS reduction. User may create a program that would pass
+    // COMPLEX value (0,0) as identity for PLUS reduction. At some later moment
+    // when the implementation starts handling COMPLEX-PLUS as known operation
+    // the existing user's program remains compilable and working correctly.
+    // I.e. with this constructor here, adding more reduction operations to the
+    // list of known operations does not break the existing programs.
+    if constexpr (is_known_identity) {
+      (void)Identity;
+      return reducer_type::getIdentity();
+
+    } else {
+      return Identity;
+    }
+  }
 
 public:
   using algo::my_is_usm;
@@ -759,11 +785,10 @@ public:
 
   /// SYCL-2020.
   /// Constructs reduction_impl when the identity value is statically known.
-  template <typename _T, typename AllocatorT,
-            std::enable_if_t<
-                sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
-                my_is_rw_acc> * = nullptr>
-  reduction_impl(buffer<_T, 1, AllocatorT> Buffer, handler &CGH,
+  template <typename AllocatorT, typename _self = self,
+            std::enable_if_t<_self::is_known_identity && _self::my_is_rw_acc>
+                * = nullptr>
+  reduction_impl(buffer<T, 1, AllocatorT> Buffer, handler &CGH,
                  bool InitializeToIdentity)
       : algo(reducer_type::getIdentity(), BinaryOperation(),
              InitializeToIdentity, rw_accessor_type{Buffer}) {
@@ -775,10 +800,9 @@ public:
   }
 
   /// Constructs reduction_impl when the identity value is statically known.
-  template <
-      typename _T = T,
-      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
-                  (my_is_rw_acc || my_is_dw_acc)> * = nullptr>
+  template <typename _self = self,
+            enable_if_t<_self::is_known_identity &&
+                        (my_is_rw_acc || my_is_dw_acc)> * = nullptr>
   reduction_impl(RedOutVar &Acc)
       : algo(reducer_type::getIdentity(), BinaryOperation(), false, Acc) {
     if (Acc.size() != 1)
@@ -790,69 +814,14 @@ public:
   /// SYCL-2020.
   /// Constructs reduction_impl when the identity value is statically known,
   /// and user still passed the identity value.
-  template <
-      typename _T, typename AllocatorT,
-      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
-                  my_is_rw_acc> * = nullptr>
-  reduction_impl(buffer<_T, 1, AllocatorT> Buffer, handler &CGH,
-                 const T & /*Identity*/, BinaryOperation,
-                 bool InitializeToIdentity)
-      : algo(reducer_type::getIdentity(), BinaryOperation(),
-             InitializeToIdentity, rw_accessor_type{Buffer}) {
-    algo::associateWithHandler(CGH);
-    if (Buffer.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_ERROR_INVALID_VALUE);
-    // For now the implementation ignores the identity value given by user
-    // when the implementation knows the identity.
-    // The SPEC could prohibit passing identity parameter to operations with
-    // known identity, but that could have some bad consequences too.
-    // For example, at some moment the implementation may NOT know the identity
-    // for COMPLEX-PLUS reduction. User may create a program that would pass
-    // COMPLEX value (0,0) as identity for PLUS reduction. At some later moment
-    // when the implementation starts handling COMPLEX-PLUS as known operation
-    // the existing user's program remains compilable and working correctly.
-    // I.e. with this constructor here, adding more reduction operations to the
-    // list of known operations does not break the existing programs.
-  }
-
-  /// Constructs reduction_impl when the identity value is statically known,
-  /// and user still passed the identity value.
-  template <
-      typename _T = T,
-      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
-                  (my_is_rw_acc || my_is_dw_acc)> * = nullptr>
-  reduction_impl(RedOutVar &Acc, const T & /*Identity*/, BinaryOperation)
-      : algo(reducer_type::getIdentity(), BinaryOperation(), my_is_dw_acc,
-             Acc) {
-    if (Acc.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_ERROR_INVALID_VALUE);
-    // For now the implementation ignores the identity value given by user
-    // when the implementation knows the identity.
-    // The SPEC could prohibit passing identity parameter to operations with
-    // known identity, but that could have some bad consequences too.
-    // For example, at some moment the implementation may NOT know the identity
-    // for COMPLEX-PLUS reduction. User may create a program that would pass
-    // COMPLEX value (0,0) as identity for PLUS reduction. At some later moment
-    // when the implementation starts handling COMPLEX-PLUS as known operation
-    // the existing user's program remains compilable and working correctly.
-    // I.e. with this constructor here, adding more reduction operations to the
-    // list of known operations does not break the existing programs.
-  }
-
   /// SYCL-2020.
   /// Constructs reduction_impl when the identity value is NOT known statically.
-  template <typename _T, typename AllocatorT,
-            enable_if_t<
-                !sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
-                my_is_rw_acc> * = nullptr>
-  reduction_impl(buffer<_T, 1, AllocatorT> Buffer, handler &CGH,
+  template <typename AllocatorT, typename _self = self,
+            enable_if_t<_self::my_is_rw_acc> * = nullptr>
+  reduction_impl(buffer<T, 1, AllocatorT> Buffer, handler &CGH,
                  const T &Identity, BinaryOperation BOp,
                  bool InitializeToIdentity)
-      : algo(Identity, BOp, InitializeToIdentity,
+      : algo(chooseIdentity(Identity), BOp, InitializeToIdentity,
              rw_accessor_type{Buffer}) {
     algo::associateWithHandler(CGH);
     if (Buffer.size() != 1)
@@ -862,11 +831,10 @@ public:
   }
 
   /// Constructs reduction_impl when the identity value is unknown.
-  template <typename _T = T, enable_if_t<!sycl::detail::IsKnownIdentityOp<
-                                             _T, BinaryOperation>::value &&
-                                         (my_is_rw_acc || my_is_dw_acc)> * = nullptr>
+  template <typename _self = self,
+            enable_if_t<_self::my_is_rw_acc || _self::my_is_dw_acc> * = nullptr>
   reduction_impl(RedOutVar &Acc, const T &Identity, BinaryOperation BOp)
-      : algo(Identity, BOp, my_is_dw_acc, Acc) {
+      : algo(chooseIdentity(Identity), BOp, my_is_dw_acc, Acc) {
     if (Acc.size() != 1)
       throw sycl::runtime_error(errc::invalid,
                                 "Reduction variable must be a scalar.",
@@ -877,75 +845,32 @@ public:
   /// The \param VarPtr is a USM pointer to memory, to where the computed
   /// reduction value is added using BinaryOperation, i.e. it is expected that
   /// the memory is pre-initialized with some meaningful value.
-  template <
-      typename _T = T,
-      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
-                  my_is_usm> * = nullptr>
+  template <typename _self = self, enable_if_t<_self::is_known_identity &&
+                                               _self::my_is_usm> * = nullptr>
   reduction_impl(T *VarPtr, bool InitializeToIdentity = false)
       : algo(reducer_type::getIdentity(), BinaryOperation(),
              InitializeToIdentity, VarPtr) {}
 
-  /// Constructs reduction_impl when the identity value is statically known,
-  /// and user still passed the identity value.
   /// The \param VarPtr is a USM pointer to memory, to where the computed
   /// reduction value is added using BinaryOperation, i.e. it is expected that
   /// the memory is pre-initialized with some meaningful value.
-  template <
-      typename _T = T,
-      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
-                  my_is_usm> * = nullptr>
-  reduction_impl(T *VarPtr, const T &Identity, BinaryOperation,
-                 bool InitializeToIdentity = false)
-      : algo(Identity, BinaryOperation(), InitializeToIdentity, VarPtr) {
-    // For now the implementation ignores the identity value given by user
-    // when the implementation knows the identity.
-    // The SPEC could prohibit passing identity parameter to operations with
-    // known identity, but that could have some bad consequences too.
-    // For example, at some moment the implementation may NOT know the identity
-    // for COMPLEX-PLUS reduction. User may create a program that would pass
-    // COMPLEX value (0,0) as identity for PLUS reduction. At some later moment
-    // when the implementation starts handling COMPLEX-PLUS as known operation
-    // the existing user's program remains compilable and working correctly.
-    // I.e. with this constructor here, adding more reduction operations to the
-    // list of known operations does not break the existing programs.
-  }
-
-  /// Constructs reduction_impl when the identity value is unknown.
-  /// The \param VarPtr is a USM pointer to memory, to where the computed
-  /// reduction value is added using BinaryOperation, i.e. it is expected that
-  /// the memory is pre-initialized with some meaningful value.
-  template <typename _T = T, enable_if_t<!sycl::detail::IsKnownIdentityOp<
-                                             _T, BinaryOperation>::value &&
-                                         my_is_usm> * = nullptr>
+  template <typename _self = self, enable_if_t<_self::my_is_usm> * = nullptr>
   reduction_impl(T *VarPtr, const T &Identity, BinaryOperation BOp,
                  bool InitializeToIdentity = false)
-      : algo(Identity, BOp, InitializeToIdentity, VarPtr) {}
+      : algo(chooseIdentity(Identity), BOp, InitializeToIdentity, VarPtr) {}
 
   /// Constructs reduction_impl when the identity value is statically known
-  template <typename _T = T, enable_if_t<sycl::detail::IsKnownIdentityOp<
-                                 _T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(span<_T, Extent> Span, bool InitializeToIdentity = false)
+  template <typename _self = self, enable_if_t<_self::is_known_identity &&
+                                               _self::my_is_usm> * = nullptr>
+  reduction_impl(span<T, Extent> Span, bool InitializeToIdentity = false)
       : algo(reducer_type::getIdentity(), BinaryOperation(),
              InitializeToIdentity, Span.data()) {}
 
-  /// Constructs reduction_impl when the identity value is statically known
-  /// and user passed an identity value anyway
-  template <
-      typename _T = T,
-      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
-                  my_is_usm> * = nullptr>
-  reduction_impl(span<_T, Extent> Span, const T & /* Identity */,
-                 BinaryOperation BOp, bool InitializeToIdentity = false)
-      : algo(reducer_type::getIdentity(), BOp, InitializeToIdentity,
-             Span.data()) {}
-
-  /// Constructs reduction_impl when the identity value is not statically known
-  template <typename _T = T, enable_if_t<!sycl::detail::IsKnownIdentityOp<
-                                             _T, BinaryOperation>::value &&
-                                         my_is_usm> * = nullptr>
+  template <typename _self = self, enable_if_t<_self::my_is_usm> * = nullptr>
   reduction_impl(span<T, Extent> Span, const T &Identity, BinaryOperation BOp,
                  bool InitializeToIdentity = false)
-      : algo(Identity, BOp, InitializeToIdentity, Span.data()) {}
+      : algo(chooseIdentity(Identity), BOp, InitializeToIdentity, Span.data()) {
+  }
 };
 
 /// A helper to pass undefined (sycl::detail::auto_name) names unmodified. We

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -526,6 +526,9 @@ class reduction_impl_algo<
     default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>>
     : public reduction_impl_common<T, BinaryOperation> {
   using base = reduction_impl_common<T, BinaryOperation>;
+  using self = reduction_impl_algo<
+      T, BinaryOperation, Dims, Extent, RedOutVar,
+      default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>>;
 
 protected:
   static constexpr bool my_is_usm = std::is_same_v<RedOutVar, T *>;
@@ -564,12 +567,17 @@ public:
   static constexpr size_t dims = Dims;
   static constexpr size_t num_elements = Extent;
 
+  template <class _self = self,
+            std::enable_if_t<_self::my_is_rw_acc> * = nullptr>
   reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
                       std::shared_ptr<rw_accessor_type> AccPointer)
       : base(Identity, BinaryOp, Init), MRWAcc(AccPointer){};
+  template <class _self = self,
+            std::enable_if_t<_self::my_is_dw_acc> * = nullptr>
   reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
                       std::shared_ptr<dw_accessor_type> AccPointer)
       : base(Identity, BinaryOp, Init), MDWAcc(AccPointer){};
+  template <class _self = self, std::enable_if_t<_self::my_is_usm> * = nullptr>
   reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
                       T *USMPointer)
       : base(Identity, BinaryOp, Init), MUSMPointer(USMPointer){};

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -569,7 +569,7 @@ public:
   static constexpr bool is_dw_acc = is_dw_acc_t<RedOutVar>::value;
   static constexpr bool is_acc = is_rw_acc | is_dw_acc;
   static_assert(!is_rw_acc || !is_dw_acc, "Can be only one at once!");
-  static_assert(!is_usm || !is_acc, "Ca be only one at once!");
+  static_assert(!is_usm || !is_acc, "Can be only one at once!");
 
   static constexpr size_t dims = Dims;
   static constexpr size_t num_elements = Extent;

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -569,23 +569,9 @@ public:
   static constexpr size_t dims = Dims;
   static constexpr size_t num_elements = Extent;
 
-  template <class _self = self,
-            std::enable_if_t<_self::my_is_rw_acc> * = nullptr>
   reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
-                      std::shared_ptr<rw_accessor_type> AccPointer)
-      : base(Identity, BinaryOp, Init), MRWAcc(AccPointer),
-        MRedOut(*AccPointer){};
-  template <class _self = self,
-            std::enable_if_t<_self::my_is_dw_acc> * = nullptr>
-  reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
-                      std::shared_ptr<dw_accessor_type> AccPointer)
-      : base(Identity, BinaryOp, Init), MDWAcc(AccPointer),
-        MRedOut(*AccPointer){};
-  template <class _self = self, std::enable_if_t<_self::my_is_usm> * = nullptr>
-  reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
-                      T *USMPointer)
-      : base(Identity, BinaryOp, Init), MUSMPointer(USMPointer),
-        MRedOut(MUSMPointer){};
+                      RedOutVar RedOut)
+      : base(Identity, BinaryOp, Init), MRedOut(std::move(RedOut)){};
 
   /// Associates the reduction accessor to user's memory with \p CGH handler
   /// to keep the accessor alive until the command group finishes the work.
@@ -726,17 +712,10 @@ private:
     return Acc;
   }
 
-  /// User's accessor to where the reduction must be written.
-  std::shared_ptr<rw_accessor_type> MRWAcc;
-  std::shared_ptr<dw_accessor_type> MDWAcc;
-
   std::shared_ptr<buffer<T, buffer_dim>> MOutBufPtr;
 
-  /// USM pointer referencing the memory to where the result of the reduction
-  /// must be written. Applicable/used only for USM reductions.
-  T *MUSMPointer = nullptr;
-
-  RedOutVar &MRedOut;
+  /// User's accessor/USM pointer to where the reduction must be written.
+  RedOutVar MRedOut;
 };
 
 /// Predicate returning true if all template type parameters except the last one
@@ -787,7 +766,7 @@ public:
   reduction_impl(buffer<_T, 1, AllocatorT> Buffer, handler &CGH,
                  bool InitializeToIdentity)
       : algo(reducer_type::getIdentity(), BinaryOperation(),
-             InitializeToIdentity, std::make_shared<rw_accessor_type>(Buffer)) {
+             InitializeToIdentity, rw_accessor_type{Buffer}) {
     algo::associateWithHandler(CGH);
     if (Buffer.size() != 1)
       throw sycl::runtime_error(errc::invalid,
@@ -799,24 +778,9 @@ public:
   template <
       typename _T = T,
       enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
-                  my_is_rw_acc> * = nullptr>
-  reduction_impl(rw_accessor_type &Acc)
-      : algo(reducer_type::getIdentity(), BinaryOperation(), false,
-             std::make_shared<rw_accessor_type>(Acc)) {
-    if (Acc.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_ERROR_INVALID_VALUE);
-  }
-
-  /// Constructs reduction_impl when the identity value is statically known.
-  template <
-      typename _T = T,
-      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
-                  my_is_dw_acc> * = nullptr>
-  reduction_impl(dw_accessor_type &Acc)
-      : algo(reducer_type::getIdentity(), BinaryOperation(), true,
-             std::make_shared<dw_accessor_type>(Acc)) {
+                  (my_is_rw_acc || my_is_dw_acc)> * = nullptr>
+  reduction_impl(RedOutVar &Acc)
+      : algo(reducer_type::getIdentity(), BinaryOperation(), false, Acc) {
     if (Acc.size() != 1)
       throw sycl::runtime_error(errc::invalid,
                                 "Reduction variable must be a scalar.",
@@ -834,7 +798,7 @@ public:
                  const T & /*Identity*/, BinaryOperation,
                  bool InitializeToIdentity)
       : algo(reducer_type::getIdentity(), BinaryOperation(),
-             InitializeToIdentity, std::make_shared<rw_accessor_type>(Buffer)) {
+             InitializeToIdentity, rw_accessor_type{Buffer}) {
     algo::associateWithHandler(CGH);
     if (Buffer.size() != 1)
       throw sycl::runtime_error(errc::invalid,
@@ -858,36 +822,10 @@ public:
   template <
       typename _T = T,
       enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
-                  my_is_rw_acc> * = nullptr>
-  reduction_impl(rw_accessor_type &Acc, const T & /*Identity*/, BinaryOperation)
-      : algo(reducer_type::getIdentity(), BinaryOperation(), false,
-             std::make_shared<rw_accessor_type>(Acc)) {
-    if (Acc.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_ERROR_INVALID_VALUE);
-    // For now the implementation ignores the identity value given by user
-    // when the implementation knows the identity.
-    // The SPEC could prohibit passing identity parameter to operations with
-    // known identity, but that could have some bad consequences too.
-    // For example, at some moment the implementation may NOT know the identity
-    // for COMPLEX-PLUS reduction. User may create a program that would pass
-    // COMPLEX value (0,0) as identity for PLUS reduction. At some later moment
-    // when the implementation starts handling COMPLEX-PLUS as known operation
-    // the existing user's program remains compilable and working correctly.
-    // I.e. with this constructor here, adding more reduction operations to the
-    // list of known operations does not break the existing programs.
-  }
-
-  /// Constructs reduction_impl when the identity value is statically known,
-  /// and user still passed the identity value.
-  template <
-      typename _T = T,
-      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
-                  my_is_dw_acc> * = nullptr>
-  reduction_impl(dw_accessor_type &Acc, const T & /*Identity*/, BinaryOperation)
-      : algo(reducer_type::getIdentity(), BinaryOperation(), true,
-             std::make_shared<dw_accessor_type>(Acc)) {
+                  (my_is_rw_acc || my_is_dw_acc)> * = nullptr>
+  reduction_impl(RedOutVar &Acc, const T & /*Identity*/, BinaryOperation)
+      : algo(reducer_type::getIdentity(), BinaryOperation(), my_is_dw_acc,
+             Acc) {
     if (Acc.size() != 1)
       throw sycl::runtime_error(errc::invalid,
                                 "Reduction variable must be a scalar.",
@@ -915,7 +853,7 @@ public:
                  const T &Identity, BinaryOperation BOp,
                  bool InitializeToIdentity)
       : algo(Identity, BOp, InitializeToIdentity,
-             std::make_shared<rw_accessor_type>(Buffer)) {
+             rw_accessor_type{Buffer}) {
     algo::associateWithHandler(CGH);
     if (Buffer.size() != 1)
       throw sycl::runtime_error(errc::invalid,
@@ -926,21 +864,9 @@ public:
   /// Constructs reduction_impl when the identity value is unknown.
   template <typename _T = T, enable_if_t<!sycl::detail::IsKnownIdentityOp<
                                              _T, BinaryOperation>::value &&
-                                         my_is_rw_acc> * = nullptr>
-  reduction_impl(rw_accessor_type &Acc, const T &Identity, BinaryOperation BOp)
-      : algo(Identity, BOp, false, std::make_shared<rw_accessor_type>(Acc)) {
-    if (Acc.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_ERROR_INVALID_VALUE);
-  }
-
-  /// Constructs reduction_impl when the identity value is unknown.
-  template <typename _T = T, enable_if_t<!sycl::detail::IsKnownIdentityOp<
-                                             _T, BinaryOperation>::value &&
-                                         my_is_dw_acc> * = nullptr>
-  reduction_impl(dw_accessor_type &Acc, const T &Identity, BinaryOperation BOp)
-      : algo(Identity, BOp, true, std::make_shared<dw_accessor_type>(Acc)) {
+                                         (my_is_rw_acc || my_is_dw_acc)> * = nullptr>
+  reduction_impl(RedOutVar &Acc, const T &Identity, BinaryOperation BOp)
+      : algo(Identity, BOp, my_is_dw_acc, Acc) {
     if (Acc.size() != 1)
       throw sycl::runtime_error(errc::invalid,
                                 "Reduction variable must be a scalar.",

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -527,6 +527,18 @@ struct accessor_dim_t<
   static constexpr int value = AccessorDims;
 };
 
+template <class T> struct get_red_t;
+template <class T> struct get_red_t<T*> {
+  using type = T;
+};
+
+template <class T, int AccessorDims, access::mode Mode,
+          access::placeholder IsPH, typename PropList>
+struct get_red_t<
+    accessor<T, AccessorDims, Mode, access::target::device, IsPH, PropList>> {
+  using type = T;
+};
+
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
           typename RedOutVar>
 class reduction_impl_algo : public reduction_impl_common<T, BinaryOperation> {
@@ -780,15 +792,14 @@ public:
 
   /// SYCL-2020.
   /// Constructs reduction_impl when the identity value is statically known.
-  template <typename AllocatorT, typename _self = self,
+  template <typename _self = self,
             std::enable_if_t<_self::is_known_identity && _self::my_is_rw_acc>
                 * = nullptr>
-  reduction_impl(buffer<T, 1, AllocatorT> Buffer, handler &CGH,
-                 bool InitializeToIdentity)
+  reduction_impl(RedOutVar &Acc, handler &CGH, bool InitializeToIdentity)
       : algo(reducer_type::getIdentity(), BinaryOperation(),
-             InitializeToIdentity, rw_accessor_type{Buffer}) {
+             InitializeToIdentity, Acc) {
     algo::associateWithHandler(CGH);
-    if (Buffer.size() != 1)
+    if (Acc.size() != 1)
       throw sycl::runtime_error(errc::invalid,
                                 "Reduction variable must be a scalar.",
                                 PI_ERROR_INVALID_VALUE);
@@ -811,15 +822,12 @@ public:
   /// and user still passed the identity value.
   /// SYCL-2020.
   /// Constructs reduction_impl when the identity value is NOT known statically.
-  template <typename AllocatorT, typename _self = self,
-            enable_if_t<_self::my_is_rw_acc> * = nullptr>
-  reduction_impl(buffer<T, 1, AllocatorT> Buffer, handler &CGH,
-                 const T &Identity, BinaryOperation BOp,
-                 bool InitializeToIdentity)
-      : algo(chooseIdentity(Identity), BOp, InitializeToIdentity,
-             rw_accessor_type{Buffer}) {
+  template <typename _self = self, enable_if_t<_self::my_is_rw_acc> * = nullptr>
+  reduction_impl(RedOutVar &Acc, handler &CGH, const T &Identity,
+                 BinaryOperation BOp, bool InitializeToIdentity)
+      : algo(chooseIdentity(Identity), BOp, InitializeToIdentity, Acc) {
     algo::associateWithHandler(CGH);
-    if (Buffer.size() != 1)
+    if (Acc.size() != 1)
       throw sycl::runtime_error(errc::invalid,
                                 "Reduction variable must be a scalar.",
                                 PI_ERROR_INVALID_VALUE);
@@ -853,20 +861,14 @@ public:
   reduction_impl(T *VarPtr, const T &Identity, BinaryOperation BOp,
                  bool InitializeToIdentity = false)
       : algo(chooseIdentity(Identity), BOp, InitializeToIdentity, VarPtr) {}
-
-  /// Constructs reduction_impl when the identity value is statically known
-  template <typename _self = self, enable_if_t<_self::is_known_identity &&
-                                               _self::my_is_usm> * = nullptr>
-  reduction_impl(span<T, Extent> Span, bool InitializeToIdentity = false)
-      : algo(reducer_type::getIdentity(), BinaryOperation(),
-             InitializeToIdentity, Span.data()) {}
-
-  template <typename _self = self, enable_if_t<_self::my_is_usm> * = nullptr>
-  reduction_impl(span<T, Extent> Span, const T &Identity, BinaryOperation BOp,
-                 bool InitializeToIdentity = false)
-      : algo(chooseIdentity(Identity), BOp, InitializeToIdentity, Span.data()) {
-  }
 };
+
+template <class BinaryOp, int Dims, size_t Extent, typename RedOutVar,
+          typename... RestTy>
+auto make_reduction(RedOutVar RedVar, RestTy &&... Rest) {
+  return reduction_impl<typename get_red_t<RedOutVar>::type, BinaryOp, Dims,
+                        Extent, RedOutVar>{RedVar, std::forward<RestTy>(Rest)...};
+}
 
 /// A helper to pass undefined (sycl::detail::auto_name) names unmodified. We
 /// must do that to avoid name collisions.
@@ -2451,11 +2453,9 @@ tuple_select_elements(TupleT Tuple, std::index_sequence<Is...>) {
 /// operation used in the reduction.
 template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
           access::placeholder IsPH>
-detail::reduction_impl<T, BinaryOperation, 0, 1,
-                       accessor<T, Dims, AccMode, access::target::device, IsPH>>
-reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
-          const T &Identity, BinaryOperation BOp) {
-  return {Acc, Identity, BOp};
+auto reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
+               const T &Identity, BinaryOperation BOp) {
+  return detail::make_reduction<BinaryOperation, 0, 1>(Acc, Identity, BOp);
 }
 
 /// Creates and returns an object implementing the reduction functionality.
@@ -2463,14 +2463,12 @@ reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
 /// must be stored \param Acc and the binary operation used in the reduction.
 /// The identity value is not passed to this version as it is statically known.
 template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
-          access::placeholder IsPH>
-std::enable_if_t<sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
-                 detail::reduction_impl<
-                     T, BinaryOperation, 0, 1,
-                     accessor<T, Dims, AccMode, access::target::device, IsPH>>>
-reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
-          BinaryOperation) {
-  return {Acc};
+          access::placeholder IsPH,
+          typename = std::enable_if_t<
+              sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value>>
+auto reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
+               BinaryOperation) {
+  return detail::make_reduction<BinaryOperation, 0, 1>(Acc);
 }
 
 /// Creates and returns an object implementing the reduction functionality.
@@ -2478,9 +2476,8 @@ reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
 /// the computed reduction must be stored \param VarPtr, identity value
 /// \param Identity, and the binary operation used in the reduction.
 template <typename T, class BinaryOperation>
-detail::reduction_impl<T, BinaryOperation, 0, 1, T *>
-reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
-  return {VarPtr, Identity, BOp};
+auto reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
+  return detail::make_reduction<BinaryOperation, 0, 1>(VarPtr, Identity, BOp);
 }
 
 /// Creates and returns an object implementing the reduction functionality.
@@ -2488,11 +2485,11 @@ reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
 /// the computed reduction must be stored \param VarPtr, and the binary
 /// operation used in the reduction.
 /// The identity value is not passed to this version as it is statically known.
-template <typename T, class BinaryOperation>
-std::enable_if_t<sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
-                 detail::reduction_impl<T, BinaryOperation, 0, 1, T *>>
-reduction(T *VarPtr, BinaryOperation) {
-  return {VarPtr};
+template <typename T, class BinaryOperation,
+          typename = std::enable_if_t<
+              sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value>>
+auto reduction(T *VarPtr, BinaryOperation) {
+  return detail::make_reduction<BinaryOperation, 0, 1>(VarPtr);
 }
 
 // ---- has_known_identity

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -253,7 +253,7 @@ using cl::sycl::detail::queue_impl;
 /// If we are given sycl::range and not sycl::nd_range we have more freedom in
 /// how to split the iteration space.
 template <typename KernelName, typename KernelType, int Dims, class Reduction>
-void reduCGFuncForRange(handler &CGH, KernelType KernelFunc,
+bool reduCGFuncForRange(handler &CGH, KernelType KernelFunc,
                         const range<Dims> &Range, size_t MaxWGSize,
                         uint32_t NumConcurrentWorkGroups, Reduction &Redu);
 
@@ -1651,11 +1651,9 @@ public:
     // for the device.
     size_t MaxWGSize =
         ext::oneapi::detail::reduGetMaxWGSize(MQueue, OneElemSize);
-    ext::oneapi::detail::reduCGFuncForRange<KernelName>(
-        *this, KernelFunc, Range, MaxWGSize, NumConcurrentWorkGroups, Redu);
-    if (Reduction::is_usm ||
-        (Reduction::has_fast_atomics && Redu.initializeToIdentity()) ||
-        (!Reduction::has_fast_atomics && Reduction::is_dw_acc)) {
+    if (ext::oneapi::detail::reduCGFuncForRange<KernelName>(
+            *this, KernelFunc, Range, MaxWGSize, NumConcurrentWorkGroups,
+            Redu)) {
       this->finalize();
       MLastEvent = withAuxHandler(QueueCopy, [&](handler &CopyHandler) {
         ext::oneapi::detail::reduSaveFinalResultToUserMem<KernelName>(

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -242,7 +242,7 @@ namespace ext {
 namespace oneapi {
 namespace detail {
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          class Algorithm>
+          typename RedOutVar, class Algorithm>
 class reduction_impl_algo;
 
 using cl::sycl::detail::enable_if_t;
@@ -2667,7 +2667,7 @@ private:
   // Make reduction friends to store buffers and arrays created for it
   // in handler from reduction methods.
   template <typename T, class BinaryOperation, int Dims, size_t Extent,
-            class Algorithm>
+            typename RedOutVar, class Algorithm>
   friend class ext::oneapi::detail::reduction_impl_algo;
 
 #ifndef __SYCL_DEVICE_ONLY__

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -242,7 +242,7 @@ namespace ext {
 namespace oneapi {
 namespace detail {
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          typename RedOutVar, class Algorithm>
+          class Algorithm, typename RedOutVar>
 class reduction_impl_algo;
 
 using cl::sycl::detail::enable_if_t;
@@ -2667,7 +2667,7 @@ private:
   // Make reduction friends to store buffers and arrays created for it
   // in handler from reduction methods.
   template <typename T, class BinaryOperation, int Dims, size_t Extent,
-            typename RedOutVar, class Algorithm>
+            class Algorithm, typename RedOutVar>
   friend class ext::oneapi::detail::reduction_impl_algo;
 
 #ifndef __SYCL_DEVICE_ONLY__

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1655,7 +1655,7 @@ public:
         *this, KernelFunc, Range, MaxWGSize, NumConcurrentWorkGroups, Redu);
     if (Reduction::is_usm ||
         (Reduction::has_fast_atomics && Redu.initializeToIdentity()) ||
-        (!Reduction::has_fast_atomics && Redu.hasUserDiscardWriteAccessor())) {
+        (!Reduction::has_fast_atomics && Reduction::my_is_dw_acc)) {
       this->finalize();
       MLastEvent = withAuxHandler(QueueCopy, [&](handler &CopyHandler) {
         ext::oneapi::detail::reduSaveFinalResultToUserMem<KernelName>(
@@ -1782,7 +1782,7 @@ public:
       });
     } // end while (NWorkItems > 1)
 
-    if (Reduction::is_usm || Redu.hasUserDiscardWriteAccessor()) {
+    if (Reduction::is_usm || Reduction::my_is_dw_acc) {
       MLastEvent = withAuxHandler(QueueCopy, [&](handler &CopyHandler) {
         ext::oneapi::detail::reduSaveFinalResultToUserMem<KernelName>(
             CopyHandler, Redu);

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -242,7 +242,7 @@ namespace ext {
 namespace oneapi {
 namespace detail {
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          class Algorithm, typename RedOutVar>
+          typename RedOutVar>
 class reduction_impl_algo;
 
 using cl::sycl::detail::enable_if_t;
@@ -2667,7 +2667,7 @@ private:
   // Make reduction friends to store buffers and arrays created for it
   // in handler from reduction methods.
   template <typename T, class BinaryOperation, int Dims, size_t Extent,
-            class Algorithm, typename RedOutVar>
+            typename RedOutVar>
   friend class ext::oneapi::detail::reduction_impl_algo;
 
 #ifndef __SYCL_DEVICE_ONLY__

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1655,7 +1655,7 @@ public:
         *this, KernelFunc, Range, MaxWGSize, NumConcurrentWorkGroups, Redu);
     if (Reduction::is_usm ||
         (Reduction::has_fast_atomics && Redu.initializeToIdentity()) ||
-        (!Reduction::has_fast_atomics && Reduction::my_is_dw_acc)) {
+        (!Reduction::has_fast_atomics && Reduction::is_dw_acc)) {
       this->finalize();
       MLastEvent = withAuxHandler(QueueCopy, [&](handler &CopyHandler) {
         ext::oneapi::detail::reduSaveFinalResultToUserMem<KernelName>(
@@ -1782,7 +1782,7 @@ public:
       });
     } // end while (NWorkItems > 1)
 
-    if (Reduction::is_usm || Reduction::my_is_dw_acc) {
+    if (Reduction::is_usm || Reduction::is_dw_acc) {
       MLastEvent = withAuxHandler(QueueCopy, [&](handler &CopyHandler) {
         ext::oneapi::detail::reduSaveFinalResultToUserMem<KernelName>(
             CopyHandler, Redu);

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -21,11 +21,15 @@ namespace sycl {
 /// Constructs a reduction object using the given buffer \p Var, handler \p CGH,
 /// reduction operation \p Combiner, and optional reduction properties.
 template <typename T, typename AllocatorT, typename BinaryOperation>
-std::enable_if_t<has_known_identity<BinaryOperation, T>::value,
-                 ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1,
-                     ext::oneapi::detail::default_reduction_algorithm<
-                         false, access::placeholder::true_t, 1>>>
+std::enable_if_t<
+    has_known_identity<BinaryOperation, T>::value,
+    ext::oneapi::detail::reduction_impl<
+        T, BinaryOperation, 0, 1,
+        accessor<T, 0, access::mode::read_write, access::target::device,
+                 access::placeholder::true_t,
+                 ext::oneapi::accessor_property_list<>>,
+        ext::oneapi::detail::default_reduction_algorithm<
+            false, access::placeholder::true_t, 1>>>
 reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, BinaryOperation,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -38,11 +42,15 @@ reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, BinaryOperation,
 /// The reduction algorithm may be less efficient for this variant as the
 /// reduction identity is not known statically and it is not provided by user.
 template <typename T, typename AllocatorT, typename BinaryOperation>
-std::enable_if_t<!has_known_identity<BinaryOperation, T>::value,
-                 ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1,
-                     ext::oneapi::detail::default_reduction_algorithm<
-                         false, access::placeholder::true_t, 1>>>
+std::enable_if_t<
+    !has_known_identity<BinaryOperation, T>::value,
+    ext::oneapi::detail::reduction_impl<
+        T, BinaryOperation, 0, 1,
+        accessor<T, 0, access::mode::read_write, access::target::device,
+                 access::placeholder::true_t,
+                 ext::oneapi::accessor_property_list<>>,
+        ext::oneapi::detail::default_reduction_algorithm<
+            false, access::placeholder::true_t, 1>>>
 reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -58,7 +66,7 @@ reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
 template <typename T, typename BinaryOperation>
 std::enable_if_t<has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1,
+                     T, BinaryOperation, 0, 1, T *,
                      ext::oneapi::detail::default_reduction_algorithm<
                          true, access::placeholder::false_t, 1>>>
 reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
@@ -75,7 +83,7 @@ reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename BinaryOperation>
 std::enable_if_t<!has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1,
+                     T, BinaryOperation, 0, 1, T *,
                      ext::oneapi::detail::default_reduction_algorithm<
                          true, access::placeholder::false_t, 1>>>
 reduction(T *, BinaryOperation, const property_list &PropList = {}) {
@@ -92,6 +100,9 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename AllocatorT, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
+    accessor<T, 0, access::mode::read_write, access::target::device,
+             access::placeholder::true_t,
+             ext::oneapi::accessor_property_list<>>,
     ext::oneapi::detail::default_reduction_algorithm<
         false, access::placeholder::true_t, 1>>
 reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
@@ -106,7 +117,7 @@ reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
 /// binary operation \p Combiner, and optional reduction properties.
 template <typename T, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
-    T, BinaryOperation, 0, 1,
+    T, BinaryOperation, 0, 1, T *,
     ext::oneapi::detail::default_reduction_algorithm<
         true, access::placeholder::false_t, 1>>
 reduction(T *Var, const T &Identity, BinaryOperation Combiner,
@@ -124,7 +135,7 @@ template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent &&
                      has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent,
+                     T, BinaryOperation, 1, Extent, T *,
                      ext::oneapi::detail::default_reduction_algorithm<
                          true, access::placeholder::false_t, 1>>>
 reduction(span<T, Extent> Span, BinaryOperation,
@@ -143,7 +154,7 @@ template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent &&
                      !has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent,
+                     T, BinaryOperation, 1, Extent, T *,
                      ext::oneapi::detail::default_reduction_algorithm<
                          true, access::placeholder::false_t, 1>>>
 reduction(span<T, Extent>, BinaryOperation,
@@ -161,7 +172,7 @@ reduction(span<T, Extent>, BinaryOperation,
 template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent,
+                     T, BinaryOperation, 1, Extent, T *,
                      ext::oneapi::detail::default_reduction_algorithm<
                          true, access::placeholder::false_t, 1>>>
 reduction(span<T, Extent> Span, const T &Identity, BinaryOperation Combiner,

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -89,9 +89,8 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 /// reduction identity value \p Identity, reduction operation \p Combiner,
 /// and optional reduction properties.
 template <typename T, typename AllocatorT, typename BinaryOperation>
-auto
-reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
-          BinaryOperation Combiner, const property_list &PropList = {}) {
+auto reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
+               BinaryOperation Combiner, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
   return ext::oneapi::detail::make_reduction<BinaryOperation, 0, 1>(

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -25,11 +25,11 @@ std::enable_if_t<
     has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
+        ext::oneapi::detail::default_reduction_algorithm<
+            false, access::placeholder::true_t, 1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
-                 ext::oneapi::accessor_property_list<>>,
-        ext::oneapi::detail::default_reduction_algorithm<
-            false, access::placeholder::true_t, 1>>>
+                 ext::oneapi::accessor_property_list<>>>>
 reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, BinaryOperation,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -46,11 +46,11 @@ std::enable_if_t<
     !has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
+        ext::oneapi::detail::default_reduction_algorithm<
+            false, access::placeholder::true_t, 1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
-                 ext::oneapi::accessor_property_list<>>,
-        ext::oneapi::detail::default_reduction_algorithm<
-            false, access::placeholder::true_t, 1>>>
+                 ext::oneapi::accessor_property_list<>>>>
 reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -66,9 +66,10 @@ reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
 template <typename T, typename BinaryOperation>
 std::enable_if_t<has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1, T *,
+                     T, BinaryOperation, 0, 1,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>>>
+                         true, access::placeholder::false_t, 1>,
+                     T *>>
 reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
@@ -83,9 +84,10 @@ reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename BinaryOperation>
 std::enable_if_t<!has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1, T *,
+                     T, BinaryOperation, 0, 1,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>>>
+                         true, access::placeholder::false_t, 1>,
+                     T *>>
 reduction(T *, BinaryOperation, const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
   (void)PropList;
@@ -100,11 +102,11 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename AllocatorT, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
+    ext::oneapi::detail::default_reduction_algorithm<
+        false, access::placeholder::true_t, 1>,
     accessor<T, 1, access::mode::read_write, access::target::device,
              access::placeholder::true_t,
-             ext::oneapi::accessor_property_list<>>,
-    ext::oneapi::detail::default_reduction_algorithm<
-        false, access::placeholder::true_t, 1>>
+             ext::oneapi::accessor_property_list<>>>
 reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
           BinaryOperation Combiner, const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -117,9 +119,10 @@ reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
 /// binary operation \p Combiner, and optional reduction properties.
 template <typename T, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
-    T, BinaryOperation, 0, 1, T *,
+    T, BinaryOperation, 0, 1,
     ext::oneapi::detail::default_reduction_algorithm<
-        true, access::placeholder::false_t, 1>>
+        true, access::placeholder::false_t, 1>,
+    T *>
 reduction(T *Var, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -135,9 +138,9 @@ template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent &&
                      has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent, T *,
+                     T, BinaryOperation, 1, Extent,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>>>
+                         true, access::placeholder::false_t, 1>, T *>>
 reduction(span<T, Extent> Span, BinaryOperation,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -154,9 +157,10 @@ template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent &&
                      !has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent, T *,
+                     T, BinaryOperation, 1, Extent,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>>>
+                         true, access::placeholder::false_t, 1>,
+                     T *>>
 reduction(span<T, Extent>, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -172,9 +176,10 @@ reduction(span<T, Extent>, BinaryOperation,
 template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent, T *,
+                     T, BinaryOperation, 1, Extent,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>>>
+                         true, access::placeholder::false_t, 1>,
+                     T *>>
 reduction(span<T, Extent> Span, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -25,8 +25,7 @@ std::enable_if_t<
     has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
-        ext::oneapi::detail::default_reduction_algorithm<
-            access::placeholder::true_t, 1>,
+        ext::oneapi::detail::default_reduction_algorithm<1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>>>
@@ -46,8 +45,7 @@ std::enable_if_t<
     !has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
-        ext::oneapi::detail::default_reduction_algorithm<
-            access::placeholder::true_t, 1>,
+        ext::oneapi::detail::default_reduction_algorithm<1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>>>
@@ -67,9 +65,7 @@ template <typename T, typename BinaryOperation>
 std::enable_if_t<has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 0, 1,
-                     ext::oneapi::detail::default_reduction_algorithm<
-                         access::placeholder::false_t, 1>,
-                     T *>>
+                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
 reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
@@ -85,9 +81,7 @@ template <typename T, typename BinaryOperation>
 std::enable_if_t<!has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 0, 1,
-                     ext::oneapi::detail::default_reduction_algorithm<
-                         access::placeholder::false_t, 1>,
-                     T *>>
+                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
 reduction(T *, BinaryOperation, const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
   (void)PropList;
@@ -102,8 +96,7 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename AllocatorT, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
-    ext::oneapi::detail::default_reduction_algorithm<
-        access::placeholder::true_t, 1>,
+    ext::oneapi::detail::default_reduction_algorithm<1>,
     accessor<T, 1, access::mode::read_write, access::target::device,
              access::placeholder::true_t,
              ext::oneapi::accessor_property_list<>>>
@@ -120,9 +113,7 @@ reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
 template <typename T, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
-    ext::oneapi::detail::default_reduction_algorithm<
-        access::placeholder::false_t, 1>,
-    T *>
+    ext::oneapi::detail::default_reduction_algorithm<1>, T *>
 reduction(T *Var, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -139,9 +130,7 @@ std::enable_if_t<Extent != dynamic_extent &&
                      has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 1, Extent,
-                     ext::oneapi::detail::default_reduction_algorithm<
-                         access::placeholder::false_t, 1>,
-                     T *>>
+                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
 reduction(span<T, Extent> Span, BinaryOperation,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -159,9 +148,7 @@ std::enable_if_t<Extent != dynamic_extent &&
                      !has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 1, Extent,
-                     ext::oneapi::detail::default_reduction_algorithm<
-                         access::placeholder::false_t, 1>,
-                     T *>>
+                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
 reduction(span<T, Extent>, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -178,9 +165,7 @@ template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 1, Extent,
-                     ext::oneapi::detail::default_reduction_algorithm<
-                         access::placeholder::false_t, 1>,
-                     T *>>
+                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
 reduction(span<T, Extent> Span, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -25,7 +25,7 @@ std::enable_if_t<
     has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
-        accessor<T, 0, access::mode::read_write, access::target::device,
+        accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>,
         ext::oneapi::detail::default_reduction_algorithm<
@@ -46,7 +46,7 @@ std::enable_if_t<
     !has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
-        accessor<T, 0, access::mode::read_write, access::target::device,
+        accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>,
         ext::oneapi::detail::default_reduction_algorithm<
@@ -100,7 +100,7 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename AllocatorT, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
-    accessor<T, 0, access::mode::read_write, access::target::device,
+    accessor<T, 1, access::mode::read_write, access::target::device,
              access::placeholder::true_t,
              ext::oneapi::accessor_property_list<>>,
     ext::oneapi::detail::default_reduction_algorithm<

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -28,10 +28,7 @@ auto reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, BinaryOperation,
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
   return ext::oneapi::detail::make_reduction<BinaryOperation, 0, 1>(
-      accessor<T, 1, access::mode::read_write, access::target::device,
-               access::placeholder::true_t,
-               ext::oneapi::accessor_property_list<>>{Var},
-      CGH, InitializeToIdentity);
+      accessor{Var}, CGH, InitializeToIdentity);
 }
 
 /// Constructs a reduction object using the given buffer \p Var, handler \p CGH,
@@ -94,10 +91,7 @@ auto reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
   return ext::oneapi::detail::make_reduction<BinaryOperation, 0, 1>(
-      accessor<T, 1, access::mode::read_write, access::target::device,
-               access::placeholder::true_t,
-               ext::oneapi::accessor_property_list<>>{Var},
-      CGH, Identity, Combiner, InitializeToIdentity);
+      accessor{Var}, CGH, Identity, Combiner, InitializeToIdentity);
 }
 
 /// Constructs a reduction object using the reduction variable referenced by

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -25,7 +25,6 @@ std::enable_if_t<
     has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
-        ext::oneapi::detail::default_reduction_algorithm<1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>>>
@@ -45,7 +44,6 @@ std::enable_if_t<
     !has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
-        ext::oneapi::detail::default_reduction_algorithm<1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>>>
@@ -62,10 +60,9 @@ reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
 /// the given USM pointer \p Var, handler \p CGH, reduction operation
 /// \p Combiner, and optional reduction properties.
 template <typename T, typename BinaryOperation>
-std::enable_if_t<has_known_identity<BinaryOperation, T>::value,
-                 ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1,
-                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
+std::enable_if_t<
+    has_known_identity<BinaryOperation, T>::value,
+    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, 1, T *>>
 reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
@@ -78,10 +75,9 @@ reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
 /// The reduction algorithm may be less efficient for this variant as the
 /// reduction identity is not known statically and it is not provided by user.
 template <typename T, typename BinaryOperation>
-std::enable_if_t<!has_known_identity<BinaryOperation, T>::value,
-                 ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1,
-                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
+std::enable_if_t<
+    !has_known_identity<BinaryOperation, T>::value,
+    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, 1, T *>>
 reduction(T *, BinaryOperation, const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
   (void)PropList;
@@ -96,7 +92,6 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename AllocatorT, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
-    ext::oneapi::detail::default_reduction_algorithm<1>,
     accessor<T, 1, access::mode::read_write, access::target::device,
              access::placeholder::true_t,
              ext::oneapi::accessor_property_list<>>>
@@ -111,9 +106,7 @@ reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
 /// the given USM pointer \p Var, reduction identity value \p Identity,
 /// binary operation \p Combiner, and optional reduction properties.
 template <typename T, typename BinaryOperation>
-ext::oneapi::detail::reduction_impl<
-    T, BinaryOperation, 0, 1,
-    ext::oneapi::detail::default_reduction_algorithm<1>, T *>
+ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, 1, T *>
 reduction(T *Var, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -126,11 +119,9 @@ reduction(T *Var, const T &Identity, BinaryOperation Combiner,
 /// the given sycl::span \p Span, reduction operation \p Combiner, and
 /// optional reduction properties.
 template <typename T, size_t Extent, typename BinaryOperation>
-std::enable_if_t<Extent != dynamic_extent &&
-                     has_known_identity<BinaryOperation, T>::value,
-                 ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent,
-                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
+std::enable_if_t<
+    Extent != dynamic_extent && has_known_identity<BinaryOperation, T>::value,
+    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, Extent, T *>>
 reduction(span<T, Extent> Span, BinaryOperation,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -144,11 +135,9 @@ reduction(span<T, Extent> Span, BinaryOperation,
 /// The reduction algorithm may be less efficient for this variant as the
 /// reduction identity is not known statically and it is not provided by user.
 template <typename T, size_t Extent, typename BinaryOperation>
-std::enable_if_t<Extent != dynamic_extent &&
-                     !has_known_identity<BinaryOperation, T>::value,
-                 ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent,
-                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
+std::enable_if_t<
+    Extent != dynamic_extent && !has_known_identity<BinaryOperation, T>::value,
+    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, Extent, T *>>
 reduction(span<T, Extent>, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -162,10 +151,9 @@ reduction(span<T, Extent>, BinaryOperation,
 /// the given sycl::span \p Span, reduction identity value \p Identity,
 /// reduction operation \p Combiner, and optional reduction properties.
 template <typename T, size_t Extent, typename BinaryOperation>
-std::enable_if_t<Extent != dynamic_extent,
-                 ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent,
-                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
+std::enable_if_t<
+    Extent != dynamic_extent,
+    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, Extent, T *>>
 reduction(span<T, Extent> Span, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -20,33 +20,32 @@ namespace sycl {
 
 /// Constructs a reduction object using the given buffer \p Var, handler \p CGH,
 /// reduction operation \p Combiner, and optional reduction properties.
-template <typename T, typename AllocatorT, typename BinaryOperation>
-std::enable_if_t<
-    has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<
-        T, BinaryOperation, 0, 1,
-        accessor<T, 1, access::mode::read_write, access::target::device,
-                 access::placeholder::true_t,
-                 ext::oneapi::accessor_property_list<>>>>
-reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, BinaryOperation,
-          const property_list &PropList = {}) {
+template <
+    typename T, typename AllocatorT, typename BinaryOperation,
+    typename = std::enable_if_t<has_known_identity<BinaryOperation, T>::value>>
+auto reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, BinaryOperation,
+               const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
-  return {Var, CGH, InitializeToIdentity};
+  return ext::oneapi::detail::make_reduction<BinaryOperation, 0, 1>(
+      accessor<T, 1, access::mode::read_write, access::target::device,
+               access::placeholder::true_t,
+               ext::oneapi::accessor_property_list<>>{Var},
+      CGH, InitializeToIdentity);
 }
 
 /// Constructs a reduction object using the given buffer \p Var, handler \p CGH,
 /// reduction operation \p Combiner, and optional reduction properties.
 /// The reduction algorithm may be less efficient for this variant as the
 /// reduction identity is not known statically and it is not provided by user.
-template <typename T, typename AllocatorT, typename BinaryOperation>
-std::enable_if_t<
-    !has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<
-        T, BinaryOperation, 0, 1,
-        accessor<T, 1, access::mode::read_write, access::target::device,
-                 access::placeholder::true_t,
-                 ext::oneapi::accessor_property_list<>>>>
+template <
+    typename T, typename AllocatorT, typename BinaryOperation,
+    typename = std::enable_if_t<!has_known_identity<BinaryOperation, T>::value>>
+ext::oneapi::detail::reduction_impl<
+    T, BinaryOperation, 0, 1,
+    accessor<T, 1, access::mode::read_write, access::target::device,
+             access::placeholder::true_t,
+             ext::oneapi::accessor_property_list<>>>
 reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -59,14 +58,14 @@ reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
 /// Constructs a reduction object using the reduction variable referenced by
 /// the given USM pointer \p Var, handler \p CGH, reduction operation
 /// \p Combiner, and optional reduction properties.
-template <typename T, typename BinaryOperation>
-std::enable_if_t<
-    has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, 1, T *>>
-reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
+template <
+    typename T, typename BinaryOperation,
+    typename = std::enable_if_t<has_known_identity<BinaryOperation, T>::value>>
+auto reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
-  return {Var, InitializeToIdentity};
+  return ext::oneapi::detail::make_reduction<BinaryOperation, 0, 1>(
+      Var, InitializeToIdentity);
 }
 
 /// Constructs a reduction object using the reduction variable referenced by
@@ -74,10 +73,10 @@ reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
 /// \p Combiner, and optional reduction properties.
 /// The reduction algorithm may be less efficient for this variant as the
 /// reduction identity is not known statically and it is not provided by user.
-template <typename T, typename BinaryOperation>
-std::enable_if_t<
-    !has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, 1, T *>>
+template <
+    typename T, typename BinaryOperation,
+    typename = std::enable_if_t<!has_known_identity<BinaryOperation, T>::value>>
+ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, 1, T *>
 reduction(T *, BinaryOperation, const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
   (void)PropList;
@@ -90,43 +89,44 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 /// reduction identity value \p Identity, reduction operation \p Combiner,
 /// and optional reduction properties.
 template <typename T, typename AllocatorT, typename BinaryOperation>
-ext::oneapi::detail::reduction_impl<
-    T, BinaryOperation, 0, 1,
-    accessor<T, 1, access::mode::read_write, access::target::device,
-             access::placeholder::true_t,
-             ext::oneapi::accessor_property_list<>>>
+auto
 reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
           BinaryOperation Combiner, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
-  return {Var, CGH, Identity, Combiner, InitializeToIdentity};
+  return ext::oneapi::detail::make_reduction<BinaryOperation, 0, 1>(
+      accessor<T, 1, access::mode::read_write, access::target::device,
+               access::placeholder::true_t,
+               ext::oneapi::accessor_property_list<>>{Var},
+      CGH, Identity, Combiner, InitializeToIdentity);
 }
 
 /// Constructs a reduction object using the reduction variable referenced by
 /// the given USM pointer \p Var, reduction identity value \p Identity,
 /// binary operation \p Combiner, and optional reduction properties.
 template <typename T, typename BinaryOperation>
-ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, 1, T *>
-reduction(T *Var, const T &Identity, BinaryOperation Combiner,
-          const property_list &PropList = {}) {
+auto reduction(T *Var, const T &Identity, BinaryOperation Combiner,
+               const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
-  return {Var, Identity, Combiner, InitializeToIdentity};
+  return ext::oneapi::detail::make_reduction<BinaryOperation, 0, 1>(
+      Var, Identity, Combiner, InitializeToIdentity);
 }
 
 #if __cplusplus >= 201703L
 /// Constructs a reduction object using the reduction variable referenced by
 /// the given sycl::span \p Span, reduction operation \p Combiner, and
 /// optional reduction properties.
-template <typename T, size_t Extent, typename BinaryOperation>
-std::enable_if_t<
-    Extent != dynamic_extent && has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, Extent, T *>>
-reduction(span<T, Extent> Span, BinaryOperation,
-          const property_list &PropList = {}) {
+template <
+    typename T, size_t Extent, typename BinaryOperation,
+    typename = std::enable_if_t<Extent != dynamic_extent &&
+                                has_known_identity<BinaryOperation, T>::value>>
+auto reduction(span<T, Extent> Span, BinaryOperation,
+               const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
-  return {Span, InitializeToIdentity};
+  return ext::oneapi::detail::make_reduction<BinaryOperation, 1, Extent>(
+      Span.data(), InitializeToIdentity);
 }
 
 /// Constructs a reduction object using the reduction variable referenced by
@@ -134,10 +134,11 @@ reduction(span<T, Extent> Span, BinaryOperation,
 /// optional reduction properties.
 /// The reduction algorithm may be less efficient for this variant as the
 /// reduction identity is not known statically and it is not provided by user.
-template <typename T, size_t Extent, typename BinaryOperation>
-std::enable_if_t<
-    Extent != dynamic_extent && !has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, Extent, T *>>
+template <
+    typename T, size_t Extent, typename BinaryOperation,
+    typename = std::enable_if_t<Extent != dynamic_extent &&
+                                !has_known_identity<BinaryOperation, T>::value>>
+ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, Extent, T *>
 reduction(span<T, Extent>, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -150,15 +151,14 @@ reduction(span<T, Extent>, BinaryOperation,
 /// Constructs a reduction object using the reduction variable referenced by
 /// the given sycl::span \p Span, reduction identity value \p Identity,
 /// reduction operation \p Combiner, and optional reduction properties.
-template <typename T, size_t Extent, typename BinaryOperation>
-std::enable_if_t<
-    Extent != dynamic_extent,
-    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, Extent, T *>>
-reduction(span<T, Extent> Span, const T &Identity, BinaryOperation Combiner,
-          const property_list &PropList = {}) {
+template <typename T, size_t Extent, typename BinaryOperation,
+          typename = std::enable_if_t<Extent != dynamic_extent>>
+auto reduction(span<T, Extent> Span, const T &Identity,
+               BinaryOperation Combiner, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
-  return {Span, Identity, Combiner, InitializeToIdentity};
+  return ext::oneapi::detail::make_reduction<BinaryOperation, 1, Extent>(
+      Span.data(), Identity, Combiner, InitializeToIdentity);
 }
 #endif
 

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -26,7 +26,7 @@ std::enable_if_t<
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
         ext::oneapi::detail::default_reduction_algorithm<
-            false, access::placeholder::true_t, 1>,
+            access::placeholder::true_t, 1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>>>
@@ -47,7 +47,7 @@ std::enable_if_t<
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
         ext::oneapi::detail::default_reduction_algorithm<
-            false, access::placeholder::true_t, 1>,
+            access::placeholder::true_t, 1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>>>
@@ -68,7 +68,7 @@ std::enable_if_t<has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 0, 1,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>,
+                         access::placeholder::false_t, 1>,
                      T *>>
 reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -86,7 +86,7 @@ std::enable_if_t<!has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 0, 1,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>,
+                         access::placeholder::false_t, 1>,
                      T *>>
 reduction(T *, BinaryOperation, const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -103,7 +103,7 @@ template <typename T, typename AllocatorT, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
     ext::oneapi::detail::default_reduction_algorithm<
-        false, access::placeholder::true_t, 1>,
+        access::placeholder::true_t, 1>,
     accessor<T, 1, access::mode::read_write, access::target::device,
              access::placeholder::true_t,
              ext::oneapi::accessor_property_list<>>>
@@ -121,7 +121,7 @@ template <typename T, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
     ext::oneapi::detail::default_reduction_algorithm<
-        true, access::placeholder::false_t, 1>,
+        access::placeholder::false_t, 1>,
     T *>
 reduction(T *Var, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
@@ -140,7 +140,8 @@ std::enable_if_t<Extent != dynamic_extent &&
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 1, Extent,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>, T *>>
+                         access::placeholder::false_t, 1>,
+                     T *>>
 reduction(span<T, Extent> Span, BinaryOperation,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -159,7 +160,7 @@ std::enable_if_t<Extent != dynamic_extent &&
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 1, Extent,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>,
+                         access::placeholder::false_t, 1>,
                      T *>>
 reduction(span<T, Extent>, BinaryOperation,
           const property_list &PropList = {}) {
@@ -178,7 +179,7 @@ std::enable_if_t<Extent != dynamic_extent,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 1, Extent,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>,
+                         access::placeholder::false_t, 1>,
                      T *>>
 reduction(span<T, Extent> Span, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {


### PR DESCRIPTION
Main idea is that memory transfer host->GPU has significant cost here unlike the
integrated GPU/shared memory. As such, make sure sycl::no_init is used for
partial sums buffer (free change). Also, modify initialization of group counter
buffer to do it with an extra kernel as that is cheaper than transferring memory
host->device.

By itself the change would have caused incompatibilities in PartialSums's
accessor type. In order to deal with this, the optimization for a single
WorkGroup was moved from the host to device code. That also made possible to
always write final user's variable inside main kernel avoiding calling
reduSaveFinalResultToUserMem for this scenario. As such, changed
reduCGFuncForRange* to return a boolean indicating if such post-processing is
needed as that is a property of a particular implementation now.